### PR TITLE
New package easyoptions

### DIFF
--- a/easyoptions-git/PKGBUILD
+++ b/easyoptions-git/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Renato Silva <br.renatosilva@gmail.com>
+
+_realname='easyoptions'
+pkgname="${_realname}-git"
+pkgdesc='Easy option parsing for Ruby and Bash'
+url='https://github.com/renatosilva/easyoptions'
+license=(BSD)
+
+arch=(any)
+pkgver=r36.7304200
+pkgrel=1
+
+makedepends=(git)
+depends=(ruby bash)
+provides=(${_realname})
+conflicts=(${_realname})
+source=("git+${url}")
+md5sums=(SKIP)
+
+pkgver() {
+    cd "${srcdir}/${_realname}"
+    printf "r%s.%s" $(git rev-list --count HEAD) $(git rev-parse --short HEAD)
+}
+
+package() {
+    cd "${srcdir}/${_realname}"
+    install -Dm755 easyoptions          "${pkgdir}/usr/bin/easyoptions"
+    install -Dm755 bash/easyoptions.sh  "${pkgdir}/usr/bin/easyoptions.sh"
+    install -Dm755 ruby/easyoptions.rb  "${pkgdir}/usr/lib/ruby/vendor_ruby/easyoptions.rb"
+    install -Dm644 LICENSE              "${pkgdir}/usr/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
[EasyOptions](https://github.com/renatosilva/easyoptions) makes it easy parsing options in Bash and Ruby scripts. For example:

* https://github.com/renatosilva/scripts/blob/master/bzrgrep.rb
* https://github.com/renatosilva/pidgin-plus/blob/master/build/winbuild.sh
