### PR TITLE
Fix Bazaar cloning in makepkg

### DIFF
--- a/pacman/0001-more-debugging-info.patch
+++ b/pacman/0001-more-debugging-info.patch
@@ -1,14 +1,14 @@
-From e27faed7c3a6ab43f0d0a8c66896143cc3ae5f5b Mon Sep 17 00:00:00 2001
+From bac7d92889fa78d583a27fba2347aa764bad665d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Fri, 13 Jun 2014 00:12:33 +0100
-Subject: [PATCH 1/2] more debugging info
+Subject: [PATCH 1/3] more debugging info
 
 ---
  lib/libalpm/util.c | 21 +++++++++++++++++++--
  1 file changed, 19 insertions(+), 2 deletions(-)
 
 diff --git a/lib/libalpm/util.c b/lib/libalpm/util.c
-index e0a48b8..4992716 100644
+index ebccc39..d565fdb 100644
 --- a/lib/libalpm/util.c
 +++ b/lib/libalpm/util.c
 @@ -300,6 +300,23 @@ int _alpm_unpack_single(alpm_handle_t *handle, const char *archive,
@@ -44,7 +44,7 @@ index e0a48b8..4992716 100644
  		exit(1);
  	} else {
  		/* this code runs for the parent only (wait on the child) */
-@@ -601,7 +618,7 @@ int _alpm_run_chroot(alpm_handle_t *handle, const char *cmd, char *const argv[])
+@@ -602,7 +619,7 @@ int _alpm_run_chroot(alpm_handle_t *handle, const char *cmd, char *const argv[])
  		if(WIFEXITED(status)) {
  			_alpm_log(handle, ALPM_LOG_DEBUG, "call to waitpid succeeded\n");
  			if(WEXITSTATUS(status) != 0) {
@@ -54,5 +54,5 @@ index e0a48b8..4992716 100644
  			}
  		} else if(WIFSIGNALED(status) != 0) {
 -- 
-2.0.0
+2.1.2
 

--- a/pacman/0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch
+++ b/pacman/0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch
@@ -1,7 +1,7 @@
-From 7db79bc7aacefb9b934ed8fe1d47f396bbcabbe5 Mon Sep 17 00:00:00 2001
+From ff3af7abbeaccd4cfa049d4f29f33d7f25ee6586 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sun, 15 Jun 2014 16:11:54 +0100
-Subject: [PATCH 2/2] Add util-msys2.{c,h} and rebase-db-msys2.{c,}
+Subject: [PATCH 2/3] Add util-msys2.{c,h} and rebase-db-msys2.{c,}
 
 .. From Cygwin's rebase program. Will be used for rebasing
 when installing in chroots when making new installer releases.
@@ -519,7 +519,7 @@ index 0000000..77c97ec
 +
 +int _alpm_load_msys_db(const char *db_name);
 diff --git a/lib/libalpm/util.c b/lib/libalpm/util.c
-index 4992716..72681a3 100644
+index d565fdb..05d24c9 100644
 --- a/lib/libalpm/util.c
 +++ b/lib/libalpm/util.c
 @@ -307,7 +307,7 @@ char *get_command_line(const char* cmd, char *const argv[])
@@ -552,10 +552,10 @@ index e8cac50..9455f47 100644
  	OP_RECURSIVE,
  	OP_SEARCH,
 diff --git a/src/pacman/pacman.c b/src/pacman/pacman.c
-index 618ea40..c9ea460 100644
+index b733933..df1ea83 100644
 --- a/src/pacman/pacman.c
 +++ b/src/pacman/pacman.c
-@@ -456,6 +456,8 @@ static int parsearg_global(int opt)
+@@ -461,6 +461,8 @@ static int parsearg_global(int opt)
  			free(config->dbpath);
  			config->dbpath = strdup(optarg);
  			break;
@@ -564,7 +564,7 @@ index 618ea40..c9ea460 100644
  		case OP_ROOT:
  		case 'r':
  			free(config->rootdir);
-@@ -839,6 +841,7 @@ static int parseargs(int argc, char *argv[])
+@@ -845,6 +847,7 @@ static int parseargs(int argc, char *argv[])
  		{"print",      no_argument,       0, OP_PRINT},
  		{"quiet",      no_argument,       0, OP_QUIET},
  		{"root",       required_argument, 0, OP_ROOT},
@@ -573,10 +573,10 @@ index 618ea40..c9ea460 100644
  		{"search",     no_argument,       0, OP_SEARCH},
  		{"unrequired", no_argument,       0, OP_UNREQUIRED},
 diff --git a/src/pacman/sync.c b/src/pacman/sync.c
-index bf19d57..dd8e794 100644
+index 4609186..2280938 100644
 --- a/src/pacman/sync.c
 +++ b/src/pacman/sync.c
-@@ -904,6 +904,27 @@ int pacman_sync(alpm_list_t *targets)
+@@ -906,6 +906,27 @@ int pacman_sync(alpm_list_t *targets)
  		return ret;
  	}
  
@@ -605,4 +605,5 @@ index bf19d57..dd8e794 100644
  		return 1;
  	}
 -- 
-2.0.0
+2.1.2
+

--- a/pacman/0003-Fix-Bazaar-cloning-support-in-makepkg.patch
+++ b/pacman/0003-Fix-Bazaar-cloning-support-in-makepkg.patch
@@ -1,0 +1,41 @@
+From 05b56288358aa9001f6c160f6fd7431551e8a2fd Mon Sep 17 00:00:00 2001
+From: Renato Silva <br.renatosilva@gmail.com>
+Date: Wed, 15 Oct 2014 16:01:04 -0300
+Subject: [PATCH 3/3] Remove useless, unreliable and buggy code from Bazaar
+ support.
+
+---
+ scripts/makepkg.sh.in | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/scripts/makepkg.sh.in b/scripts/makepkg.sh.in
+index 0ef77ca..8d0ea66 100644
+--- a/scripts/makepkg.sh.in
++++ b/scripts/makepkg.sh.in
+@@ -444,23 +444,6 @@ download_bzr() {
+ 			exit 1
+ 		fi
+ 	elif (( ! HOLDVER )); then
+-		# Make sure we are fetching the right repo
+-		local distant_url="$(bzr info $url 2> /dev/null | sed -n '/branch root/{s/  branch root: //p;q;}')"
+-		local local_url="$(bzr config parent_location -d $dir)"
+-		if [[ -n $distant_url ]]; then
+-			if [[ $distant_url != "$local_url" ]]; then
+-				error "$(gettext "%s is not a branch of %s")" "$dir" "$url"
+-				plain "$(gettext "Aborting...")"
+-				exit 1
+-			fi
+-		else
+-			if [[ $url != "$local_url" ]] ; then
+-				error "$(gettext "%s is not a branch of %s")" "$dir" "$url"
+-				error "$(gettext "The local URL is %s")" "$local_url"
+-				plain "$(gettext "Aborting...")"
+-				exit 1
+-			fi
+-		fi
+ 		msg2 "$(gettext "Pulling %s ...")" "${displaylocation}"
+ 		cd_safe "$dir"
+ 		if ! bzr pull "$url" --overwrite; then
+-- 
+2.1.2
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 pkgname=pacman
 _base_ver=4.1.2
 pkgver=4.1.2.5831.8f603c2
-pkgrel=1
+pkgrel=2
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="http://www.archlinux.org/pacman/"
@@ -22,7 +23,8 @@ depends=('bash>=4.2.045'
          'xz')
 optdepends=('diffutils' 'vim')
 checkdepends=('python2')
-makedepends=('asciidoc'
+makedepends=('gcc'
+             'asciidoc'
              'autoconf'
              'automake-wrapper'
              'doxygen'
@@ -48,7 +50,8 @@ source=("$pkgname"::'git://github.com/Alexpux/MSYS2-pacman.git'
         "makepkg_mingw64.conf"
         "makepkg-mingw"
         "0001-more-debugging-info.patch"
-        "0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch")
+        "0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch"
+        "0003-Fix-Bazaar-cloning-support-in-makepkg.patch")
 md5sums=('SKIP'
          '8fa93febeebaeb62dfa7b63d2846ce52'
          '8fa93febeebaeb62dfa7b63d2846ce52'
@@ -56,8 +59,9 @@ md5sums=('SKIP'
          'eac2f0002729f0db4e841e2594d14123'
          'c8859429e8bc1abc3e170fac912df58d'
          '6d09ad2af496334e3f9f546c1e586676'
-         '9cbad99274b1013e91ddc1e311a79cc5'
-         '6aec4e88b9103114e42932697f86aa33')
+         'd31670df405fcf2cefd2ff80369cf81f'
+         'ecc66e9c8ec7f895d5a0af7777c0b4e5'
+         '6aef6929f2d1233eb7249b0049e31c7d')
 
 pkgver() {
   cd "$srcdir/$pkgname"
@@ -69,6 +73,7 @@ prepare() {
   cd $srcdir/$pkgname
   git am "$srcdir"/0001-more-debugging-info.patch
   git am "$srcdir"/0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch
+  git am "$srcdir"/0003-Fix-Bazaar-cloning-support-in-makepkg.patch
 }
 
 build() {


### PR DESCRIPTION
This is because makepkg was requiring the cloned repository to be removed across builds, because it was erroneously thinking that the repository is not a real clone of `$source`. More info in the commit message.