### PR TITLE
repman: Add to base group

### DIFF
--- a/repman/PKGBUILD
+++ b/repman/PKGBUILD
@@ -8,8 +8,9 @@ license=(GPL)
 
 arch=(i686 x86_64)
 pkgver=r18.69da11c
-pkgrel=1
+pkgrel=2
 
+groups=(base)
 depends=(pacman)
 makedepends=(git)
 provides=(${_name})


### PR DESCRIPTION
Repman should now be included in the MSYS2 installer.