### PR TITLE
pacman: makepkg-mingw improvements

### DIFF
--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -5,7 +5,7 @@
 pkgname=pacman
 _base_ver=4.2.0
 pkgver=4.2.0.6041.2789db6
-pkgrel=1
+pkgrel=2
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="http://www.archlinux.org/pacman/"
@@ -62,7 +62,7 @@ md5sums=('SKIP'
          '81de71e027953c5a83515ea94988ff9d'
          '5f2e5de12835d81ec946a283062c7ddf'
          '9586dbe2ba79ca8971a95523d6b4f81b'
-         '6d09ad2af496334e3f9f546c1e586676'
+         'f284fbfe409cac2cb56972aa6956cacc'
          '3478ac5ab27b8cdb289d1ac3792b16ec'
          'feb2bcc62db05f7bc6ac97d43dd0643a'
          '9ee3ca289031ca9c92db2805b75c1944'

--- a/pacman/makepkg-mingw
+++ b/pacman/makepkg-mingw
@@ -59,22 +59,39 @@ else
 fi
 
 readonly ALL_OFF BOLD BLUE GREEN RED YELLOW
-declare -r MINGW_INSTALLS="mingw64 mingw32"
+MINGW_INSTALLS="${MINGW_INSTALLS:-mingw64 mingw32}"
 
 for _mingw in ${MINGW_INSTALLS}; do
+  if [ ! "${_mingw}" = 'mingw32' -a ! "${_mingw}" = 'mingw64' ]; then
+    print_error "Requested mingw installation '${_mingw}', but only 'mingw32' and 'mingw64' are allowed."
+    exit 1
+  fi
+done
+
+for _arg in "$@"; do
+  if [ ${_arg} = "--help" -o ${_arg} = "-h" -o ${_arg} = "--version" -o ${_arg} = "-V" ]; then
+    /usr/bin/makepkg $@
+    exit 0
+  fi
+done
+
+for _mingw in ${MINGW_INSTALLS}; do
+  case ${_mingw} in
+    mingw32)
+      _arch=i686
+      _msystem=MINGW32
+    ;;
+    mingw64)
+      _arch=x86_64
+      _msystem=MINGW64
+    ;;
+  esac
+
   if [ -f "/${_mingw}/bin/gcc.exe" ]; then
-    MSYSTEM=MINGW32 \
+    MSYSTEM=${_msystem} \
     PATH=/${_mingw}/bin:$(echo $PATH | tr ':' '\n' | awk '$0 != "/opt/bin"' | paste -sd:) \
     /usr/bin/makepkg --config /etc/makepkg_${_mingw}.conf $@ || exit 1
   else
-    case $_mingw in
-      mingw32)
-        _arch=i686
-      ;;
-      mingw64)
-        _arch=x86_64
-      ;;
-    esac
     print_warning "You don't have installed mingw-w64 toolchain for architecture ${_arch}."
     print_warning "To install it run: 'pacman -S mingw-w64-${_arch}-toolchain'"
   fi


### PR DESCRIPTION
- Set correct `MSYSTEM`: previously, it was being set to `MINGW32` for both architectures
- Allow user to set `MINGW_INSTALLATIONS`: user can use this envvar to choose which architecture to build for
- Don't print help output twice: if `makepkg-mingw` is passed `-h` or `-V`