### PR TITLE
Fix MAN_DIRS expansion in makepkg.conf

### DIFF
--- a/pacman/makepkg.conf
+++ b/pacman/makepkg.conf
@@ -97,7 +97,7 @@ STRIP_SHARED="--strip-unneeded"
 #-- Options to be used when stripping static libraries. See `man strip' for details.
 STRIP_STATIC="--strip-debug"
 #-- Manual (man and info) directories to compress (if zipman is specified)
-MAN_DIRS=({{,usr/}{,local/}{,share/},opt/*}/{man,info} mingw{32,64}{,/local}{,/share},opt/*}/{man,info})
+MAN_DIRS=({{,usr/}{,local/}{,share/},opt/*/}{man,info} mingw{32,64}{{,/local}{,/share},/opt/*}/{man,info})
 #-- Doc directories to remove (if !docs is specified)
 DOC_DIRS=({,usr/}{,local/}{,share/}{doc,gtk-doc} mingw{32,64}/{,local/}{,share/}{doc,gtk-doc} opt/*/{doc,gtk-doc})
 #-- Files to be removed from all packages (if purge is specified)

--- a/pacman/makepkg_mingw32.conf
+++ b/pacman/makepkg_mingw32.conf
@@ -111,7 +111,7 @@ STRIP_SHARED="--strip-unneeded"
 #-- Options to be used when stripping static libraries. See `man strip' for details.
 STRIP_STATIC="--strip-debug"
 #-- Manual (man and info) directories to compress (if zipman is specified)
-MAN_DIRS=(mingw32{,/local}{,/share},opt/*}/{man,info})
+MAN_DIRS=(mingw32{{,/local}{,/share},/opt/*}/{man,info})
 #-- Doc directories to remove (if !docs is specified)
 DOC_DIRS=(mingw32/{,local/}{,share/}{doc,gtk-doc})
 #-- Files to be removed from all packages (if purge is specified)

--- a/pacman/makepkg_mingw64.conf
+++ b/pacman/makepkg_mingw64.conf
@@ -111,7 +111,7 @@ STRIP_SHARED="--strip-unneeded"
 #-- Options to be used when stripping static libraries. See `man strip' for details.
 STRIP_STATIC="--strip-debug"
 #-- Manual (man and info) directories to compress (if zipman is specified)
-MAN_DIRS=(mingw64{,/local}{,/share},opt/*}/{man,info})
+MAN_DIRS=(mingw64{{,/local}{,/share},/opt/*}/{man,info})
 #-- Doc directories to remove (if !docs is specified)
 DOC_DIRS=(mingw64/{,local/}{,share/}{doc,gtk-doc})
 #-- Files to be removed from all packages (if purge is specified)


### PR DESCRIPTION
MAN_DIRS was missing a brace, which prevented man pages for mingw packages from being compressed. I added the missing brace and also moved around some slashes to prevent doubled and missing slashes in the paths.