### PR TITLE
Add ccache-wrapper PKGBUILD

### DIFF
--- a/ccache-wrapper/PKGBUILD
+++ b/ccache-wrapper/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Andrew Whatson <whatson@gmail.com>
+
+pkgname=ccache-wrapper
+pkgver=1
+pkgrel=1
+pkgdesc='Wrapper scripts for ccache'
+arch=('any')
+license=('GPL')
+depends=('bash')
+optdepends=(
+  'mingw-w64-i686-ccache-git'
+  'mingw-w64-i686-gcc'
+  'mingw-w64-i686-clang'
+  'mingw-w64-x86_64-ccache-git'
+  'mingw-w64-x86_64-gcc'
+  'mingw-w64-x86_64-clang'
+)
+
+package() {
+  reallibdir=/usr/lib/${pkgname}
+  libdir=${pkgdir}/${reallibdir}
+  etcdir=${pkgdir}/etc/profile.d
+
+  compilers_any='
+    gcc.exe
+    g++.exe
+    c++.exe
+    clang.exe
+    clang++.exe
+  '
+
+  compilers_32='
+    i686-w64-mingw32-gcc.exe
+    i686-w64-mingw32-gcc-4.9.2.exe
+    i686-w64-mingw32-g++.exe
+    i686-w64-mingw32-c++.exe
+  '
+
+  compilers_64='
+    x86_64-w64-mingw32-gcc.exe
+    x86_64-w64-mingw32-gcc-4.9.2.exe
+    x86_64-w64-mingw32-g++.exe
+    x86_64-w64-mingw32-c++.exe
+  '
+
+  mkdir -p ${libdir}/{mingw32,mingw64}
+
+  # install wrapper script
+  ( echo '#!/bin/bash'
+    echo 'ccache $(basename $0) "$@"'
+  ) > ${libdir}/ccache-wrapper.sh
+  chmod +x ${libdir}/ccache-wrapper.sh
+
+  # install mingw32 wrappers
+  for compiler in $compilers_any $compilers_32; do
+    cp ${libdir}/ccache-wrapper.sh ${libdir}/mingw32/${compiler}
+  done
+
+  # install mingw64 wrappers
+  for compiler in $compilers_any $compilers_64; do
+    cp ${libdir}/ccache-wrapper.sh ${libdir}/mingw64/${compiler}
+  done
+ 
+  # install profile hook 
+  mkdir -p ${etcdir}
+  ( echo 'export CCACHE_PATH="$PATH"'
+    echo 'export PATH="'${reallibdir}'/${MSYSTEM,,}:$PATH"'
+  ) > ${etcdir}/ccache-wrapper.sh
+}


### PR DESCRIPTION
On linux systems (eg. ubuntu), ccache installs symlinks to /usr/lib/ccache which provide transparent caching when added to PATH.  On windows we don't really have symlinks, but a shell script can do the job.

This package:
  - installs shell script wrappers to /usr/lib/ccache-wrapper/{mingw32,mingw64}
  - provides wrappers for current gcc and clang executables
  - adds a hook to profile.d adding the appropriate wrappers to PATH

Concerns:

No hard dependencies in the package means that it's possible to get silly errors using wrappers when ccache or the selected compiler isn't installed.  Should this package be split into separate mingw32/mingw64 versions, with appropriate dependencies?  We don't want to force people to install toolchains they dont' need.

The hard-coded list of compilers will be annoying to maintain.  It's probably already missing some supported toolchains, and would need updating regulary for version changes.  Maybe we could add wrappers for installed compilers as a post-install hook?  Any compilers installed *after* ccache-wrappers would be missed though, so maybe a setup-ccache-wrappers script to be run manually?  Ugh.

Automatically modifying PATH via the profile.d hook might be controversial.  Setting CCACHE_DISABLE=1 prevents caching when needed, but maybe the PATH modification should be opt-in?

Any suggestions for improvement are greatly appreciated.