### PR TITLE
Jhbuild

### DIFF
--- a/asciidoc/PKGBUILD
+++ b/asciidoc/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=asciidoc
 pkgver=8.6.9
-pkgrel=3
+pkgrel=4
 pkgdesc='Text document format for short documents, articles, books and UNIX man pages.'
 arch=('any')
 url='http://www.methods.co.nz/asciidoc/'
@@ -33,7 +33,7 @@ prepare() {
   # python2 fix
   for file in asciidocapi.py a2x.py asciidoc.py filters/music/music2png.py filters/latex/latex2png.py \
     filters/code/code-filter.py filters/graphviz/graphviz2png.py; do
-  sed -i 's_#!/usr/bin/env python_#!/usr/bin/env python2_' $file
+  sed -i 's_#!/usr/bin/env python_#!/usr/bin/python2_' $file
   done
   #sed -i -e 's_sys:python_sys:python2_g' -e 's_sys3:python_sys3:python2_g' xhtml11.conf
   #sed -i 's_sys:python_sys:python2_g' xhtml11-quirks.conf

--- a/asciidoc/PKGBUILD
+++ b/asciidoc/PKGBUILD
@@ -24,10 +24,9 @@ md5sums=('c59018f105be8d022714b826b0be130a'
          'edf28bbe5c832f4261b117275a03f457')
 
 prepare() {
-  cd ${startdir}
-  [ -d ${srcdir}/${pkgname}-${pkgver} ] || tar -xzvf ${pkgname}-${pkgver}.tar.gz -C ${srcdir}
+  tar -xzvf ${pkgname}-${pkgver}.tar.gz --recursive-unlink
 
-  cd ${srcdir}/${pkgname}-${pkgver}
+  cd ${pkgname}-${pkgver}
 
   patch -p1 -i ${srcdir}/0001-W32-confdir.msys2.patch
   # python2 fix

--- a/gnome-common/PKGBUILD
+++ b/gnome-common/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+pkgname=gnome-common
+pkgver=3.14.0
+pkgrel=1
+pkgdesc="Common development macros for GNOME"
+arch=('any')
+license=('GPL')
+url="http://www.gnome.org"
+source=(http://download.gnome.org/sources/${pkgname}/${pkgver%.*}/${pkgname}-$pkgver.tar.xz
+        Werror-format-remove.patch)
+sha256sums=('4c00242f781bb441289f49dd80ed1d895d84de0c94bfc2c6818a104c9e39262c'
+            'c88704be75556c08a62645588ec70050f58def421f849c0519213c8709e36906')
+
+prepare() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+  #patch -p1 -i ${srcdir}/Werror-format-remove.patch
+}
+
+build() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+  ./configure --prefix=/usr
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+}

--- a/gnome-common/Werror-format-remove.patch
+++ b/gnome-common/Werror-format-remove.patch
@@ -1,0 +1,10 @@
+--- gnome-common-3.10.0/macros2/gnome-compiler-flags.m4.orig	2013-09-07 07:57:28.000000000 +0400
++++ gnome-common-3.10.0/macros2/gnome-compiler-flags.m4	2014-02-22 22:04:03.861200000 +0400
+@@ -47,7 +47,6 @@
+         -Werror=pointer-arith \
+         -Werror=init-self \
+         -Werror=format-security \
+-        -Werror=format=2 \
+         -Werror=missing-include-dirs \
+     "
+ 

--- a/jhbuild-git/PKGBUILD
+++ b/jhbuild-git/PKGBUILD
@@ -1,0 +1,46 @@
+# Contributor (MSYS2): David Macek <david.macek.0@gmail.com>
+# Maintainer (AUR): Kerrick Staley <mail@kerrickstaley.com>
+# Contributor (AUR): Thijs Vermeir <thijsvermeir@gmail.com>
+
+_realname=jhbuild
+pkgname="${_realname}-git"
+pkgver=8203.d465faa
+pkgrel=1
+pkgdesc='Downloads and compiles Gnome "modules", i.e. source code packages.'
+url='https://live.gnome.org/Jhbuild/'
+arch=('i686' 'x86_64')
+license=('GPL')
+depends=('python2')
+makedepends=('rsync'
+             'subversion'
+             'gnome-common'
+             'git'
+             'intltool'
+             'gnome-doc-utils'
+             'yelp-tools')
+provides=("${_realname}")
+conflicts=("${_realname}")
+source=('git://git.gnome.org/jhbuild'
+        'module_autogenargs.patch')
+sha256sums=('SKIP'
+            'f92dd2735e47d0032f4069fbf1c4d1207c83eabd0a6317ea78f39d6157e854b2')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd "${_realname}"
+    patch -p1 -i "${srcdir}/module_autogenargs.patch"
+    sed 's/env python2$/python2/' -i scripts/jhbuild.in
+    ./autogen.sh --prefix=/usr PYTHON=/usr/bin/python2
+    make
+}
+
+package() {
+    cd "${_realname}"
+    make DESTDIR="${pkgdir}" install
+    install -d "${pkgdir}/usr/share/jhbuild"
+    cp -dr modulesets "${pkgdir}/usr/share/jhbuild"
+}

--- a/jhbuild-git/module_autogenargs.patch
+++ b/jhbuild-git/module_autogenargs.patch
@@ -1,0 +1,21 @@
+diff --git a/jhbuild/defaults.jhbuildrc b/jhbuild/defaults.jhbuildrc
+index e467a49..de715c4 100644
+--- a/jhbuild/defaults.jhbuildrc
++++ b/jhbuild/defaults.jhbuildrc
+@@ -78,7 +78,15 @@ repos = {}
+ cvsroots = {}
+ svnroots = {}
+ branches = {}
+-module_autogenargs = {}
++# Arch-specific setting: we need to pass PYTHON=/usr/bin/python2 when building some modules.
++module_autogenargs = {
++    'cairo': autogenargs + ' ac_cv_prog_RANLIB=gcc-ranlib RANLIB=gcc-ranlib AR=gcc-ar',
++    'evolution-data-server': autogenargs + ' PYTHON=/usr/bin/python2',
++    'gobject-introspection': autogenargs + ' PYTHON=/usr/bin/python2',
++    'itstool': autogenargs + ' PYTHON=/usr/bin/python2',
++    'telepathy-mission-control': autogenargs + ' PYTHON=/usr/bin/python2',
++    'WebKit': autogenargs + ' PYTHON=/usr/bin/python2',
++}
+ module_cmakeargs = {}
+ module_makeargs = {}
+ module_extra_env = {}


### PR DESCRIPTION
- `jhbuild` is used for building `xorg`
- `gnome-common` is a dependency for `jhbuild`
- `asciidoc` didn't work in mingw shell because it used mingw/python instead of msys/python