### PR TITLE
Indexers

### DIFF
--- a/ctags/PKGBUILD
+++ b/ctags/PKGBUILD
@@ -8,7 +8,7 @@ arch=("i686" "x86_64")
 url="http://ctags.sourceforge.net/"
 license="GPL"
 source=("http://sourceforge.net/projects/ctags/files/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.gz")
-sha1sums=('482da1ecd182ab39bbdc09f2f02c9fba8cd20030')
+sha1sums=("482da1ecd182ab39bbdc09f2f02c9fba8cd20030")
 
 build () {
   cd "${pkgname}-${pkgver}"

--- a/global/PKGBUILD
+++ b/global/PKGBUILD
@@ -24,14 +24,14 @@ build () {
   ./configure --prefix=/usr \
               --build=${CHOST} \
               --host=${CHOST} \
-              --with-exuberant-ctags \
               --enable-shared \
-              --disable-static
+              --disable-static \
+              --with-exuberant-ctags=ctags
   make
 }
 
 package () {
   cd "${pkgname}-${pkgver}"
   make prefix="${pkgdir}/usr" install
-  install -Dm0644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm0644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/idutils/PKGBUILD
+++ b/idutils/PKGBUILD
@@ -8,7 +8,7 @@ arch=("i686" "x86_64")
 url="https://www.gnu.org/software/idutils/"
 license="GPL3"
 source=("https://ftp.gnu.org/gnu/idutils/${pkgname}-${pkgver}.tar.xz")
-sha1sums=('cb977ce3e4b2bacda85797e9048986e1c1765148')
+sha1sums=("cb977ce3e4b2bacda85797e9048986e1c1765148")
 
 build () {
   cd "${pkgname}-${pkgver}"
@@ -21,6 +21,6 @@ build () {
 package () {
   cd "${pkgname}-${pkgver}"
   make prefix="${pkgdir}/usr" install
-  
-  rm -rf ${pkgdir}/usr/lib
+  install -Dm644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  rm -rf "${pkgdir}/usr/lib"
 }

--- a/python-pygments/PKGBUILD
+++ b/python-pygments/PKGBUILD
@@ -11,7 +11,7 @@ license="BSD"
 makedepends=("python2-setuptools" "python3-setuptools")
 source=("https://pypi.python.org/packages/source/P/Pygments/Pygments-${pkgver}.tar.gz")
 noextract=("Pygments-${pkgver}.tar.gz")
-sha1sums=('fe2c8178a039b6820a7a86b2132a2626df99c7f8')
+sha1sums=("fe2c8178a039b6820a7a86b2132a2626df99c7f8")
 
 prepare () {
   # workaround for symlink issue
@@ -21,11 +21,11 @@ prepare () {
 
 package_python2-pygments () {
   depends=("python2")
+  install="python2-pygments.install"
 
   cd "Pygments-${pkgver}"
   python2 setup.py install --root="${pkgdir}" -O1
-  
-  mv "${pkgdir}"/usr/bin/pygmentize "${pkgdir}"/usr/bin/pygmentize2
+  mv "${pkgdir}/usr/bin/pygmentize" "${pkgdir}/usr/bin/pygmentize2"
   install -Dm644 external/pygments.bashcomp "${pkgdir}/usr/share/bash-completion/completions/pygmentize2"
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/python-pygments/python2-pygments.install
+++ b/python-pygments/python2-pygments.install
@@ -1,0 +1,7 @@
+post_install() {
+  echo "pygmentize has been renamed to pygmentize2"
+}
+
+post_upgrade() {
+  post_install "$1"
+}


### PR DESCRIPTION
I've fixed the exuberant ctags + python pygments integration with gnu global: it is now fully functional. The binary is ```ctags``` instead of ```/bin/usr/ctags``` on purpose, so the user can specify it's favourite on the PATH.

Changed pygments installation so that a message is presented to the user when installing, notifying him of the binary renaming, due to what was discussed in 1904be2733a5698ea45a80eb5063ba6861cc1823.

Also installed a missing LICENSE file and corrected another one as well as missing quotings.