### PR TITLE
Clean up /usr/sbin and /usr/etc

### DIFF
--- a/cyrus-sasl/PKGBUILD
+++ b/cyrus-sasl/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=(cyrus-sasl libsasl libsasl-devel)
 pkgver=2.1.26
-pkgrel=6
+pkgrel=7
 pkgdesc="Cyrus Simple Authentication Service Layer (SASL) library"
 arch=('i686' 'x86_64')
 url="http://cyrusimap.web.cmu.edu/"
@@ -71,6 +71,7 @@ build() {
   cd ${srcdir}/$pkgname-$pkgver
   ./configure \
     --prefix=/usr \
+    --sbindir=/usr/bin \
     --build=$CHOST \
     --host=$CHOST \
     --with-configdir=/etc/sasl2:/etc/sasl:/usr/lib/sasl2 \

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=filesystem
-pkgver=2015.02
-pkgrel=2
+pkgver=2015.03
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -55,7 +55,7 @@ md5sums=('3b95f37af49beb642c8fe174dd1f63fc'
          '05835065b59828a5c29a2c9688ca63cf'
          '292ad5cdd78abac9d694cc06819a96fc'
          'b29485d6e832dce9b27a2c025b53bdd8'
-         '0ac754e63fa39fcd1b6ae586a72dd225'
+         '695743141128ede5a2ccd3d2c4be6da2'
          '118fa00617d4d0b2eb337dd565d44494'
          '39c1d2412eb62864c8c07cb2557c7da3'
          '3b6753667b61800db1a30c614efd1ee1'
@@ -76,7 +76,6 @@ build() {
 package() {
   cd ${pkgdir}
 
-  #
   # setup root filesystem
   #
   for d in dev etc home usr var opt mingw32 mingw64; do
@@ -86,6 +85,7 @@ package() {
   mkdir -p tmp
 
   # setup /etc
+  #
   install -d etc/{fstab.d,skel,profile.d,post-install}
   for f in bash.bashrc bash.bash_logout fstab shells profile nsswitch.conf; do
     install -m644 ${srcdir}/${f} etc/
@@ -96,6 +96,7 @@ package() {
   done
 
   # user configuration file skeletons
+  #
   install -m755 ${srcdir}/dot.bashrc etc/skel/.bashrc
   install -m755 ${srcdir}/dot.inputrc etc/skel/.inputrc
   install -m755 ${srcdir}/dot.bash_profile etc/skel/.bash_profile
@@ -110,38 +111,31 @@ package() {
   install -m755 ${srcdir}/mingw64_shell.bat mingw64_shell.bat
 
   # setup /var
+  #
   for d in cache/man local opt log/old lib/misc empty; do
     install -d -m755 var/${d}
   done
   mkdir -p var/tmp
 
+  # setup /usr
   #
-  # setup /usr hierarchy
-  #
-  for d in bin include lib sbin share/misc src; do
+  for d in bin include lib share/misc src; do
     install -d -m755 usr/${d}
   done
   for d in $(seq 8); do
     install -d -m755 usr/share/man/man${d}
   done
   # various shell scripts
-  for f in cmd start dep-search; do
+  for f in cmd start dep-search regen-info.sh; do
     install -m755 ${srcdir}/${f} usr/bin
   done
-  install -m755 ${srcdir}/regen-info.sh usr/sbin
 
+  # setup /mingw hierarchies
   #
-  # setup /mingw32 hierarchy
-  #
-  for d in bin etc include lib share; do
-    install -d -m755 mingw32/${d}
-  done
-
-  #
-  # setup /mingw64 hierarchy
-  #
-  for d in bin etc include lib share; do
-    install -d -m755 mingw64/${d}
+  for m in mingw32 mingw64; do
+    for d in bin etc include lib share; do
+      install -d -m755 ${m}/${d}
+    done
   done
 
   install -Dm 644 ${srcdir}/cygwin.ldif usr/share/Msys/cygwin.ldif

--- a/filesystem/profile
+++ b/filesystem/profile
@@ -126,7 +126,7 @@ export PATH MANPATH INFOPATH PKG_CONFIG_PATH USER TMP TEMP PRINTER HOSTNAME PS1 
 export TERM=xterm-256color
 
 if [ "$MAYBE_FIRST_START" = "true" ]; then
-  sh /usr/sbin/regen-info.sh
+  sh /usr/bin/regen-info.sh
   
   if [ -f "/usr/bin/update-ca-trust" ]
   then 

--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,16 +2,16 @@
 
 pkgname=gdb
 pkgver=7.8.1
-pkgrel=2
+pkgrel=3
 _gcc_ver=4.9.2
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
 license=('GPL3')
 url="http://www.gnu.org/software/gdb/"
 groups=('base-devel')
-depends=("libiconv" "zlib" "expat" "libiconv" "python2")
+depends=("libiconv" "zlib" "expat" "libiconv" "python2" "libexpat" "libreadline")
 #checkdepends=('dejagnu' 'bc')
-makedepends=("libiconv-devel" "zlib-devel" "ncurses-devel" "liblzma-devel")
+makedepends=("libiconv-devel" "zlib-devel" "ncurses-devel" "liblzma-devel" "libexpat-devel" "libreadline-devel")
 options=('staticlibs' '!distcc' '!ccache')
 source=("http://ftp.gnu.org/gnu/gdb/gdb-${pkgver}.tar.xz"{,.sig}
         'gdbinit'
@@ -68,8 +68,8 @@ package() {
   make DESTDIR=${pkgdir} install
 
   # install "custom" system gdbinit
-  install -D -m644 ${srcdir}/gdbinit ${pkgdir}/usr/etc/gdbinit
-  sed -i 's|%GCC_NAME%|gcc-'${_gcc_ver}'|g' ${pkgdir}/usr/etc/gdbinit
+  install -D -m644 ${srcdir}/gdbinit ${pkgdir}/etc/gdbinit
+  sed -i 's|%GCC_NAME%|gcc-'${_gcc_ver}'|g' ${pkgdir}/etc/gdbinit
 
   # these are shipped by binutils
   rm -fr ${pkgdir}/usr/{include,lib}/ ${pkgdir}/usr/share/locale/

--- a/heimdal/PKGBUILD
+++ b/heimdal/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('heimdal' 'heimdal-libs' 'heimdal-devel')
 pkgver=1.5.3
-pkgrel=5
+pkgrel=6
 pkgdesc="Implementation of Kerberos V5 libraries"
 arch=('i686' 'x86_64')
 url="http://www.h5l.org/"
@@ -41,7 +41,8 @@ build() {
 
   ./configure --build=${CHOST} \
     --prefix=/usr \
-    --libexecdir=/usr/sbin \
+    --libexecdir=/usr/libexec \
+    --sbindir=/usr/bin \
     --sysconfdir=/etc/krb5 \
     --mandir=/usr/share/man \
     --datadir=/var/lib/heimdal \
@@ -55,7 +56,7 @@ build() {
     --disable-kcm \
     --disable-ndbm-db \
     --disable-heimdal-documentation
-
+  
   make LDFLAGS="${LDFLAGS} -no-undefined"
   setup
 }
@@ -68,7 +69,7 @@ setup() {
   # Remove daemons and their manpages
   for i in telnetd ftpd rshd; do
     rm ${destdir}/usr/share/man/man8/${i}.8
-    rm ${destdir}/usr/sbin/${i}
+    rm ${destdir}/usr/libexec/${i}
   done
 
   # Rename clients and their manpages
@@ -105,7 +106,7 @@ package_heimdal() {
   rm -f ${pkgdir}/usr/bin/*-config
   rm -f ${pkgdir}/usr/bin/*.dll
   cp -rf ${srcdir}/dest/etc ${pkgdir}/
-  cp -rf ${srcdir}/dest/usr/sbin ${pkgdir}/usr/
+  cp -rf ${srcdir}/dest/usr/libexec ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
 }
 

--- a/tar/PKGBUILD
+++ b/tar/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=tar
 pkgver=1.28
-pkgrel=2
+pkgrel=3
 pkgdesc="Utility used to store, backup, and transport files"
 arch=('i686' 'x86_64')
 url="http://www.gnu.org/software/tar/tar.html"
@@ -33,6 +33,7 @@ build() {
   cd ${srcdir}/$pkgname-$pkgver
   ./configure --build=${CHOST} \
     --prefix=/usr \
+    --sbindir=/usr/bin \
     --libexecdir=/usr/lib/tar \
     --enable-backup-scripts
   make

--- a/tzcode/PKGBUILD
+++ b/tzcode/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=tzcode
 _ver=2015a
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc="Sources for time zone and daylight saving time data"
 arch=('i686' 'x86_64')
 url="http://www.iana.org/time-zones"
@@ -24,7 +24,7 @@ source=(
         tzcode-man8.patch)
 sha1sums=('b08b129f32ad9f5d260c8f519dbcafeb33118e34'
           '22541acf7ffed47b7ee67959c112b6f23b1afefb'
-          'c6a8a818e2d6926f6b00fb6d6549fcf05af0e150'
+          'fdbd29f4b204c74f477cbba9777daa0e2dbed2e8'
           'ea2354956f2ae3c09527647486f7f501049d01da'
           '46feb526f958e4cc027e253345fbe31b41dc5bf4'
           '2095c6a471634cc9574b24a9b661d1f32952a11a'

--- a/tzcode/tzcode-makefile.patch
+++ b/tzcode/tzcode-makefile.patch
@@ -30,7 +30,7 @@
  # The "tzselect", "zic", and "zdump" commands get installed in. . .
  
 -ETCDIR=		$(TOPDIR)/etc
-+ETCDIR=		$(TOPDIR)/sbin
++ETCDIR=		$(TOPDIR)/bin
  
  # If you "make INSTALL", the "date" command gets installed in. . .
  

--- a/util-linux/PKGBUILD
+++ b/util-linux/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=("util-linux" "libutil-linux" "libutil-linux-devel")
 pkgver=2.25.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Miscellaneous system utilities for Linux"
 arch=('i686' 'x86_64')
 license=('GPL3')
@@ -18,7 +18,8 @@ source=(ftp://ftp.kernel.org/pub/linux/utils/$pkgname/v${pkgver%.*}/$pkgname-$pk
         2.25.1-lslogins.patch
         2.25.1-ncurses-reentrant.patch
         2.25.1-scanf-ms.patch
-        2.25.1-get_terminal_width.patch)
+        2.25.1-get_terminal_width.patch
+        2.25.1-relocate-sbin-to-usr-bin.patch)
 md5sums=('2ff36a8f8ede70f66c5ad0fb09e40e79'
          '7bfa7a252cf44b70d489580dead33b4a'
          '4a6a486f374d90985ca4d636c6305b51'
@@ -29,7 +30,8 @@ md5sums=('2ff36a8f8ede70f66c5ad0fb09e40e79'
          'b3c5b5275ceb07c2b3637700e21c8322'
          'feaa429e437a28d73c0a07d4c0359757'
          '9a66b65aee60df39ff6e7c7e06bc6a8c'
-         '6e3a5043d221352f8a6cbb28d216a247')
+         '6e3a5043d221352f8a6cbb28d216a247'
+         '99d791175a775e32ac7bee401d5b4a41')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -42,8 +44,9 @@ prepare() {
   patch -p2 -i $srcdir/2.25.1-lslogins.patch
   patch -p2 -i $srcdir/2.25.1-ncurses-reentrant.patch
   patch -p2 -i $srcdir/2.25.1-scanf-ms.patch
-  patch -p1 -i ${srcdir}/2.24.2-msysize.patch
+  patch -p1 -i $srcdir/2.24.2-msysize.patch
   patch -p2 -i $srcdir/2.25.1-get_terminal_width.patch
+  patch -p1 -i $srcdir/2.25.1-relocate-sbin-to-usr-bin.patch
   autoreconf -fi
 }
 
@@ -130,9 +133,8 @@ package_util-linux() {
   conflicts=('getopt')
   replaces=('getopt')
 
-  mkdir -p ${pkgdir}/usr/{bin,sbin}
+  mkdir -p ${pkgdir}/usr/bin
   cp ${srcdir}/dest/usr/bin/*.exe ${pkgdir}/usr/bin/
-  cp ${srcdir}/dest/usr/sbin/*.exe ${pkgdir}/usr/sbin/
   cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
 }
 


### PR DESCRIPTION
Affected recipes: cyrus-sasl, filesystem, gdb, heimdal, tar, tzcode, util-linux

Also:
- add missing dependencies to gdb
- re-format filesystem PKGBUILD slightly

I can split the commit into multiple ones, if needed.