### PR TITLE
python2, python3: Extended existing patch to fix another crash

### DIFF
--- a/python2/0260-wrong-parameters.patch
+++ b/python2/0260-wrong-parameters.patch
@@ -1,12 +1,6 @@
-diff -r c087ac6fc171 Modules/_ctypes/_ctypes.c
---- a/Modules/_ctypes/_ctypes.c	Wed Jan 28 10:52:49 2015 +0200
-+++ b/Modules/_ctypes/_ctypes.c	Wed Jan 28 19:53:12 2015 +0900
-@@ -637,17 +637,17 @@ CDataType_in_dll(PyObject *type, PyObjec
-         return NULL;
-     }
- #else
-     address = (void *)ctypes_dlsym(handle, name);
-     if (!address) {
+--- a/Modules/_ctypes/_ctypes.c	2014-12-10 16:59:51.000000000 +0100
++++ b/Modules/_ctypes/_ctypes.c	2015-03-13 03:17:29.360113700 +0100
+@@ -642,7 +642,7 @@
  #ifdef __CYGWIN__
  /* dlerror() isn't very helpful on cygwin */
          PyErr_Format(PyExc_ValueError,
@@ -15,8 +9,12 @@ diff -r c087ac6fc171 Modules/_ctypes/_ctypes.c
                       name);
  #else
          PyErr_SetString(PyExc_ValueError, ctypes_dlerror());
- #endif
-         return NULL;
-     }
- #endif
-     return PyCData_AtAddress(type, address);
+@@ -3393,7 +3393,7 @@
+ #ifdef __CYGWIN__
+ /* dlerror() isn't very helpful on cygwin */
+         PyErr_Format(PyExc_AttributeError,
+-                     "function '%s' not found (%s) ",
++                     "function '%s' not found",
+                      name);
+ #else
+         PyErr_SetString(PyExc_AttributeError, ctypes_dlerror());

--- a/python2/PKGBUILD
+++ b/python2/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python2
 pkgver=2.7.9
-pkgrel=2
+pkgrel=3
 _pybasever=2.7
 pkgdesc="A high-level scripting language"
 arch=('i686' 'x86_64')
@@ -46,7 +46,7 @@ sha1sums=('3172f6e957713c2d9fca462cc16068222fd1b9d3'
           'a1806da6956df1860cc23ff3701cd80cbb126b87'
           'e6e13cb541efaaf228355cb1d7d5cd8574757c72'
           '80975639f5ad78fd15b8f81bd98fb460c4ee05c4'
-          'd00ab9da69c45fa3d0c41c2de46b1967c1101d76'
+          'bc6e2e25b51c01ad5fd009c8f7a961a6648f5609'
           'fb78069fadcf5394ba380e26e371ad687d344415')
 
 prepare() {

--- a/python3/3.3-wrong-parameters.patch
+++ b/python3/3.3-wrong-parameters.patch
@@ -1,12 +1,6 @@
-diff -r c087ac6fc171 Modules/_ctypes/_ctypes.c
---- a/Modules/_ctypes/_ctypes.c	Wed Jan 28 10:52:49 2015 +0200
-+++ b/Modules/_ctypes/_ctypes.c	Wed Jan 28 19:53:12 2015 +0900
-@@ -637,17 +637,17 @@ CDataType_in_dll(PyObject *type, PyObjec
-         return NULL;
-     }
- #else
-     address = (void *)ctypes_dlsym(handle, name);
-     if (!address) {
+--- a/Modules/_ctypes/_ctypes.c	2013-11-17 08:22:55.000000000 +0100
++++ b/Modules/_ctypes/_ctypes.c	2015-03-13 03:09:39.333858300 +0100
+@@ -567,7 +567,7 @@
  #ifdef __CYGWIN__
  /* dlerror() isn't very helpful on cygwin */
          PyErr_Format(PyExc_ValueError,
@@ -15,8 +9,12 @@ diff -r c087ac6fc171 Modules/_ctypes/_ctypes.c
                       name);
  #else
          PyErr_SetString(PyExc_ValueError, ctypes_dlerror());
- #endif
-         return NULL;
-     }
- #endif
-     return PyCData_AtAddress(type, address);
+@@ -3251,7 +3251,7 @@
+ #ifdef __CYGWIN__
+ /* dlerror() isn't very helpful on cygwin */
+         PyErr_Format(PyExc_AttributeError,
+-                     "function '%s' not found (%s) ",
++                     "function '%s' not found",
+                      name);
+ #else
+         PyErr_SetString(PyExc_AttributeError, ctypes_dlerror());

--- a/python3/PKGBUILD
+++ b/python3/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=python
 pkgver=3.3.3
-pkgrel=3
+pkgrel=4
 _pybasever=3.3
 pkgdesc="Next generation of the python high-level scripting language"
 arch=('i686' 'x86_64')
@@ -54,7 +54,7 @@ sha1sums=('af4e75a34bd538c79b9871227c2e7f56569ac107'
           'b303a2da60abded2ca020dfb63da5d5184c1d92f'
           'd3cbd7286fab191a5a9086cea1a9a3dc386e17da'
           '1ec44391e21ad83cd149e83e65b2e77af13b9fbd'
-          'd00ab9da69c45fa3d0c41c2de46b1967c1101d76'
+          '0ff694de5df467fbc1a5152751f5b1f9884a7209'
           '4f5ef705c8806900313480e13fb8d34c49aeb77a'
           'e0f3d9388e888357a920c32a4ca525ef4ec69343')
 prepare() {


### PR DESCRIPTION
Diagnosed the source of useretail's crash. The `wrong-parameters` patch fixed one place where formatting string had one too many `%s`, but did not fix the other one.

I have the feeling that this should go upstream.