### PR TITLE
Add bc package

### DIFF
--- a/bc/PKGBUILD
+++ b/bc/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Sundaram Ramaswamy <legends2k@yahoo.com>
+
+pkgname=bc
+pkgver=1.06
+pkgrel=1
+pkgdesc="An arbitrary precision calculator language"
+arch=('i686' 'x86_64')
+url="http://www.gnu.org/software/bc"
+license=('GPL')
+depends=('gcc' 'libreadline' 'ncurses')
+builddepends=('libreadline-devel' 'ncurses-devel')
+source=(ftp://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz)
+md5sums=('d44b5dddebd8a7a7309aea6c36fda117')
+
+build () {
+    cd "${pkgname}-${pkgver}"
+    
+    ./configure --prefix=/usr \
+                --build=${CHOST} \
+                --host=${CHOST} \
+                --with-readline
+
+    make
+}
+
+check () {
+    cd "${pkgname}-${pkgver}"
+    echo "quit" | ./bc/bc -l Test/checklib.b # 10 failures
+}
+
+package () {
+    cd "${pkgname}-${pkgver}"
+    make prefix="${pkgdir}/usr" install
+}


### PR DESCRIPTION
[`bc`](https://www.gnu.org/software/bc) is an arbitrary precision numeric processing calculator language; a utility included in the POSIX P1003.2/D11 draft standard.

This package is GNU's implementation of `bc`.