### PR TITLE
filesystem: Fix execute permissions on files (should fix #222)

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=filesystem
 pkgver=2015.04
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -51,9 +51,9 @@ md5sums=('3b95f37af49beb642c8fe174dd1f63fc'
          'ff5b9ce40fb39b9c745f188bde6dabea'
          '162d83283cf4088f00dab39573eb2802'
          'b0eb2ba1c1bc95e678309fd36dac27db'
-         '7ce73bb507ef5cf5cd7c0e163272ec8a'
-         'c6a0f663a5ba268f295e93f98fe6ae56'
-         '05835065b59828a5c29a2c9688ca63cf'
+         '60b98a16b10ca531034bb82ab56018b0'
+         '62c83d220f0d5e0afe6532d7f0f55a66'
+         'ba944a5704589a598920d2564853b009'
          '292ad5cdd78abac9d694cc06819a96fc'
          'b29485d6e832dce9b27a2c025b53bdd8'
          'cc8ed4d45d2971670cb6df1928dc8f23'
@@ -98,13 +98,13 @@ package() {
 
   # user configuration file skeletons
   #
-  install -m755 ${srcdir}/dot.bashrc etc/skel/.bashrc
-  install -m755 ${srcdir}/dot.inputrc etc/skel/.inputrc
-  install -m755 ${srcdir}/dot.bash_profile etc/skel/.bash_profile
-  install -m755 ${srcdir}/dot.bash_logout etc/skel/.bash_logout
+  install -m644 ${srcdir}/dot.bashrc etc/skel/.bashrc
+  install -m644 ${srcdir}/dot.inputrc etc/skel/.inputrc
+  install -m644 ${srcdir}/dot.bash_profile etc/skel/.bash_profile
+  install -m644 ${srcdir}/dot.bash_logout etc/skel/.bash_logout
 
-  install -m755 ${srcdir}/profile.tzset.sh etc/profile.d/tzset.sh
-  install -m755 ${srcdir}/profile.lang.sh etc/profile.d/lang.sh
+  install -m644 ${srcdir}/profile.tzset.sh etc/profile.d/tzset.sh
+  install -m644 ${srcdir}/profile.lang.sh etc/profile.d/lang.sh
 
   install -m644 ${srcdir}/msys2.ico msys2.ico
   install -m755 ${srcdir}/msys2_shell.bat msys2_shell.bat

--- a/filesystem/mingw32_shell.bat
+++ b/filesystem/mingw32_shell.bat
@@ -1,3 +1,4 @@
+:
 @echo off
 
 rem ember value of GOTO: is used to know recursion has happened.

--- a/filesystem/mingw64_shell.bat
+++ b/filesystem/mingw64_shell.bat
@@ -1,3 +1,4 @@
+:
 @echo off
 
 rem ember value of GOTO: is used to know recursion has happened.

--- a/filesystem/msys2_shell.bat
+++ b/filesystem/msys2_shell.bat
@@ -1,3 +1,4 @@
+:
 @echo off
 
 rem ember value of GOTO: is used to know recursion has happened.


### PR DESCRIPTION
I have not actually tested if the bits make it into the msys2 distribution archive.

I don't see any downside to adding the empty label (`:`) to the batch files, but I could be wrong.