### PR TITLE
Fix git stash in mingw shells

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -35,12 +35,14 @@ source=(#"http://git-core.googlecode.com/files/git-$pkgver.tar.gz"
         http://fossies.org/linux/misc/git-manpages-$pkgver.tar.gz
         1.7.9-cygwin.patch
         git-1.9.0-manifest-msys2.patch
-        git-1.8.4-msys2.patch)
+        git-1.8.4-msys2.patch
+        git-2.3.5-mingw-pwd.patch)
 md5sums=('8101cd7497ee64d1ed07d12541826a30'
          '209ed840bb155bc6fc129675ee7bb0a2'
          'c33c9dfa2944a0de9151a7af7a63a27b'
          'f5975b367aa0979006bb07b297ef081b'
-         '9f9170a30dfb7643df4948cdae5bb864')
+         '9f9170a30dfb7643df4948cdae5bb864'
+         '18381075d8c134d8c4b03c9a566f40f0')
 
 prepare() {
   cd "$srcdir/$pkgname-$pkgver"
@@ -48,6 +50,7 @@ prepare() {
   patch -p2 -i ${srcdir}/1.7.9-cygwin.patch
   patch -p1 -i ${srcdir}/git-1.9.0-manifest-msys2.patch
   patch -p1 -i ${srcdir}/git-1.8.4-msys2.patch
+  patch -p2 -i ${srcdir}/git-2.3.5-mingw-pwd.patch
 
   local _arch=
   if [ "${CARCH}" == 'x86_64' ]; then

--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -47,6 +47,7 @@ md5sums=('8101cd7497ee64d1ed07d12541826a30'
 prepare() {
   cd "$srcdir/$pkgname-$pkgver"
 
+  rm -f compat/win32/git.manifest compat/win32/resource.rc
   patch -p2 -i ${srcdir}/1.7.9-cygwin.patch
   patch -p1 -i ${srcdir}/git-1.9.0-manifest-msys2.patch
   patch -p1 -i ${srcdir}/git-1.8.4-msys2.patch

--- a/git/git-2.3.5-mingw-pwd.patch
+++ b/git/git-2.3.5-mingw-pwd.patch
@@ -1,0 +1,39 @@
+--- src/git-2.3.5/git-sh-setup.sh.old	2015-04-01 00:14:52.000000000 +0200
++++ src/git-2.3.5/git-sh-setup.sh	2015-04-18 21:47:15.753865900 +0200
+@@ -306,28 +305,17 @@ case $(uname -s) in
+ 	find () {
+ 		/usr/bin/find "$@"
+ 	}
+-	# git sees Windows-style pwd
+-	pwd () {
+-		builtin pwd -W
+-	}
+-	is_absolute_path () {
+-		case "$1" in
+-		[/\\]* | [A-Za-z]:*)
+-			return 0 ;;
+-		esac
+-		return 1
+-	}
+ 	;;
+-*)
+-	is_absolute_path () {
+-		case "$1" in
+-		/*)
+-			return 0 ;;
+-		esac
+-		return 1
+-	}
+ esac
+
++is_absolute_path () {
++	case "$1" in
++	/*)
++		return 0 ;;
++	esac
++	return 1
++}
++
+ # Make sure we are in a valid repository of a vintage we understand,
+ # if we require to be in a git repository.
+ git_dir_init () {


### PR DESCRIPTION
I have not tested this change much, but I have confirmed it fixes `git stash` in a mingw shell.

Even if the change turns out to be problematic, it definitely shouldn't affect msys2 shell or cmd, as neither of them presents as a mingw shell.

Fixes #30. Fixes #189. Ref #141 (not sure if this fixes it).