### PR TITLE
Fix empty MINGW_MOUNT_POINT handling

### DIFF
--- a/filesystem/profile
+++ b/filesystem/profile
@@ -94,7 +94,7 @@ profile_d ()
     [ -e "${file}" ] && . "${file}"
   done
   
-  if [ -n ${MINGW_MOUNT_POINT} ]; then
+  if [ -n "${MINGW_MOUNT_POINT}" ]; then
     for file in $(export LC_COLLATE=C; echo ${MINGW_MOUNT_POINT}/etc/profile.d/*.$1); do
       [ -e "${file}" ] && . "${file}"
     done


### PR DESCRIPTION
```
$ MINGW_MOUNT_POINT=; [ -n $MINGW_MOUNT_POINT ]; echo $?
0
```

```
$ MINGW_MOUNT_POINT=; [ -n "$MINGW_MOUNT_POINT" ]; echo $?
1
```