### PR TITLE
Add ragel as a tool

### DIFF
--- a/ragel/PKGBUILD
+++ b/ragel/PKGBUILD
@@ -1,0 +1,24 @@
+pkgname=ragel
+pkgver=6.9
+pkgrel=1
+pkgdesc="Compiles finite state machines from regular languages into executable C, C++, Objective-C, or D code."
+arch=('i686' 'x86_64')
+url="http://www.colm.net/open-source/ragel/"
+license=('GPL')
+depends=('gcc-libs')
+source=("http://www.colm.net/files/$pkgname/$pkgname-$pkgver.tar.gz")
+md5sums=('0c3110d7f17f7af4d9cb774443898dc1')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  ./configure --prefix=/usr
+  make
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  make DESTDIR="$pkgdir/" install
+  install -m0644 -D ragel.vim "$pkgdir"/usr/share/vim/vimfiles/syntax/ragel.vim
+}


### PR DESCRIPTION
It is based on:
* https://github.com/KaOS-Community-Packages/ragel/blob/master/PKGBUILD
* https://github.com/johnbartholomew/pkgbuilds/blob/master/ragel/PKGBUILD

And it works well locally in order to compile a library I wanted to use this for.