### PR TITLE
atool: New package.

### DIFF
--- a/atool/PKGBUILD
+++ b/atool/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Gore Liu <goreliu@126.com>
+
+pkgname=atool
+pkgver=0.39.0
+pkgrel=1
+pkgdesc="A script for managing file archives of various types"
+arch=('any')
+url="http://www.nongnu.org/atool/"
+license=('GPL3')
+depends=('file' 'perl')
+optdepends=('bzip2: for using atool with bzip2 compressed archives'
+            'gzip: for using atool with gzip compressed archives'
+            'xz: for using atool with lzma compressed archives'
+            'p7zip: for using atool with 7z archives'
+            'tar: for using atool with tar archives'
+            'zip: for using atool for creating zip archives'
+            'unzip: for using atool for unpacking archives')
+source=(http://savannah.nongnu.org/download/$pkgname/$pkgname-$pkgver.tar.gz)
+sha256sums=('aaf60095884abb872e25f8e919a8a63d0dabaeca46faeba87d12812d6efc703b')
+
+build() {
+  cd "${srcdir}"/${pkgname}-${pkgver}
+
+  ./configure --prefix=/usr
+}
+
+package() {
+  cd "${srcdir}"/${pkgname}-${pkgver}
+
+  make prefix="${pkgdir}"/usr install
+}


### PR DESCRIPTION
Name           : atool
Description    : A script for managing file archives of various types
Architecture   : any
URL            : http://www.nongnu.org/atool/
Licenses       : GPL3