### PR TITLE
Problems building git package: missing iconv and prove not in path

### DIFF
--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -20,7 +20,8 @@ depends=('curl'
          'perl-libwww'
          'perl-MIME-tools'
          'perl-Net-SMTP-SSL'
-         'perl-TermReadKey')
+         'perl-TermReadKey'
+         'libiconv-devel')
 makedepends=('libcurl-devel' 'python2' 'less' 'openssh' 'rsync')
 optdepends=(#'tk: gitk and git gui'
             'python2: various helper scripts'
@@ -92,7 +93,7 @@ check() {
   # http://comments.gmane.org/gmane.comp.version-control.git/202020
   make \
     NO_SVN_TESTS=y \
-    DEFAULT_TEST_TARGET=prove \
+    DEFAULT_TEST_TARGET=/usr/bin/core_perl/prove \
     GIT_PROVE_OPTS="$jobs -Q" \
     GIT_TEST_OPTS="--root=/tmp/git-test" \
     test


### PR DESCRIPTION
I tried to build msys2 git but it failed due to missing iconv and prove not in path. I installed `libiconv-devel` and then added `prove` to the path by doing `export PATH=$PATH:/usr/bin/core_perl`. In the end I abandoned my build because prove was taking too long so I'm not certain these are solutions.
