### PR TITLE
Build bc without readline support

### DIFF
--- a/bc/PKGBUILD
+++ b/bc/PKGBUILD
@@ -7,18 +7,17 @@ pkgdesc="An arbitrary precision calculator language"
 arch=('i686' 'x86_64')
 url="http://www.gnu.org/software/bc"
 license=('GPL')
-depends=('gcc' 'libreadline' 'ncurses')
-builddepends=('libreadline-devel' 'ncurses-devel')
+depends=('gcc' 'ncurses')
+builddepends=('ncurses-devel')
 source=(ftp://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz)
 md5sums=('d44b5dddebd8a7a7309aea6c36fda117')
 
 build () {
     cd "${pkgname}-${pkgver}"
-    
+
     ./configure --prefix=/usr \
                 --build=${CHOST} \
                 --host=${CHOST} \
-                --with-readline
 
     make
 }


### PR DESCRIPTION
- Fix build failure on mingw64 when enabling readline feature
