### PR TITLE
Add pass and pwgen packages

### DIFF
--- a/pass/PKGBUILD
+++ b/pass/PKGBUILD
@@ -1,0 +1,18 @@
+# Maintainer: micbou <contact@micbou.com>
+
+pkgname='pass'
+pkgver=1.6.5
+pkgrel=2
+pkgdesc='Stores, retrieves, generates, and synchronizes passwords securely'
+arch=('any')
+url='http://zx2c4.com/projects/password-store/'
+license=('GPL2')
+depends=('bash' 'gnupg' 'pwgen' 'tree')
+optdepends=('git: for Git support')
+source=(http://git.zx2c4.com/password-store/snapshot/password-store-${pkgver}.tar.xz)
+md5sums=('2c4468360c678184051e76f03c2f6b04')
+
+package() {
+  cd "${srcdir}/password-store-$pkgver/"
+  make DESTDIR="${pkgdir}" FORCE_ALL=1 install
+}

--- a/pwgen/PKGBUILD
+++ b/pwgen/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: micbou <contact@micbou.com>
+
+pkgname=pwgen
+pkgver=2.07
+pkgrel=1
+pkgdesc='Password generator for creating easily memorable passwords'
+arch=('x86_64' 'i686')
+url='http://sourceforge.net/projects/pwgen/'
+license=('GPL')
+depends=('msys2-runtime')
+source=("http://downloads.sourceforge.net/sourceforge/pwgen/$pkgname-$pkgver.tar.gz")
+sha256sums=('eb74593f58296c21c71cd07933e070492e9222b79cedf81d1a02ce09c0e11556')
+
+prepare() {
+  cd "$pkgname-$pkgver"
+  autoconf
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+  ./configure --prefix=/usr --mandir=/usr/share/man
+  make
+}
+
+package() {
+  make -C "$pkgname-$pkgver" DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
Based on Archlinux [pass](https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/pass) and [pwgen](https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/pwgen) PKGBUILDs (pass depends on pwgen). 
pwgen tested on 32 and 64-bits. pass is just a script.