### PR TITLE
ncurses: fix crash when TERM refers to an unknown terminal

### DIFF
--- a/ncurses/0001-CRITICAL-fix-return-value-of-drv_CanHandle-on-unknow.patch
+++ b/ncurses/0001-CRITICAL-fix-return-value-of-drv_CanHandle-on-unknow.patch
@@ -1,0 +1,58 @@
+From 41f152b6e8bea7e92be960158ef4bd9df34dd8a0 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 26 Jun 2015 13:19:49 +0000
+Subject: [PATCH] CRITICAL: fix return value of drv_CanHandle on unknown
+ terminal
+
+By mistake, the 5.9 -> 6.0 patches tried to reuse the `ret_error*()`
+functions in both lib_driver.c and tinfo_driver.c. However, in the
+latter file, the return value must be FALSE (because the type is bool),
+not ERR (as it must be in lib_driver.c). As a consequence,
+`_nc_get_driver()` assumed *success* when we actually failed, and worse:
+we already free()d data that is still happily used by the code
+afterwards because it assumed that we were successful.
+
+Work around this by reinstating the `ret_error*()` family that returns
+FALSE in tinfo_driver.c.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ ncurses/tinfo/tinfo_driver.c | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/ncurses/tinfo/tinfo_driver.c b/ncurses/tinfo/tinfo_driver.c
+index a17accd..9597466 100644
+--- a/ncurses/tinfo/tinfo_driver.c
++++ b/ncurses/tinfo/tinfo_driver.c
+@@ -113,6 +113,28 @@ drv_Name(TERMINAL_CONTROL_BLOCK * TCB)
+     return "tinfo";
+ }
+ 
++/* We need to return FALSE here, not ERR. */
++#undef ret_error
++#define ret_error(code, fmt, arg)	if (errret) {\
++					    *errret = code;\
++					    returnCode(FALSE);\
++					} else {\
++					    fprintf(stderr, fmt, arg);\
++					    exit(EXIT_FAILURE);\
++					}
++
++#undef ret_error1
++#define ret_error1(code, fmt, arg)	ret_error(code, "'%s': " fmt, arg)
++
++#undef ret_error0
++#define ret_error0(code, msg)		if (errret) {\
++					    *errret = code;\
++					    returnCode(FALSE);\
++					} else {\
++					    fprintf(stderr, msg);\
++					    exit(EXIT_FAILURE);\
++					}
++
+ static bool
+ drv_CanHandle(TERMINAL_CONTROL_BLOCK * TCB, const char *tname, int *errret)
+ {
+-- 
+2.4.4
+

--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -4,13 +4,21 @@ pkgname=('ncurses' 'ncurses-devel')
 _basever=6.0
 _date=20150613
 pkgver=${_basever}.${_date}
-pkgrel=1
+pkgrel=2
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="http://www.gnu.org/software/ncurses/"
 license=('MIT')
-source=("ncurses-${pkgver}.tar.gz"::"http://invisible-island.net/datafiles/current/ncurses.tar.gz")
-md5sums=('0c6a0389d004c78f4a995bc61884a563')
+source=("ncurses-${pkgver}.tar.gz"::"http://invisible-island.net/datafiles/current/ncurses.tar.gz"
+	0001-CRITICAL-fix-return-value-of-drv_CanHandle-on-unknow.patch)
+md5sums=('0c6a0389d004c78f4a995bc61884a563'
+	d028c8a447339bf5f1762b91938e66d6)
+
+prepare() {
+  cd ${srcdir}/$pkgname-${_basever}-${_date}
+
+  patch -p1 -i ${srcdir}/0001-CRITICAL-fix-return-value-of-drv_CanHandle-on-unknow.patch
+}
 
 build() {
   cd ${srcdir}/$pkgname-${_basever}-${_date}


### PR DESCRIPTION
A but that was recently introduced into the 6.x development branch of
ncurses causes free()d data to be reused by mistake, leading to a crash.

You can verify this by setting TERM to, say, `msys` and then running
`bash.exe --login -i`.

This fixes https://github.com/git-for-windows/git/issues/222

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>