### PR TITLE
Modify "can't create socket" occurred

### DIFF
--- a/tmux-git/PKGBUILD
+++ b/tmux-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=tmux-git
-pkgver=2.0.171.g7acc4ad
+pkgver=2.0.198.g9a0ce98
 pkgrel=1
 pkgdesc='A terminal multiplexer'
 url='http://tmux.github.io/'
@@ -12,9 +12,11 @@ conflicts=('tmux')
 depends=('ncurses' 'libevent')
 makedepends=('git' 'ncurses-devel' 'libevent-devel')
 source=("$pkgname"::'git+https://github.com/tmux/tmux.git'
-        'msys-platform.patch')
+        'msys-platform.patch'
+        'no-check-dirs-permission.patch')
 md5sums=('SKIP'
-         'b175ece57d04168245f63dbf51f87cd0')
+         'b175ece57d04168245f63dbf51f87cd0'
+         'fa2ad87bf927d9a6ecf846557ab0cda6')
 
 pkgver() {
   cd "${srcdir}"/$pkgname
@@ -24,6 +26,7 @@ pkgver() {
 prepare() {
   cd "${srcdir}"/$pkgname
   patch -p1 -i "${srcdir}"/msys-platform.patch
+  patch -p0 -i "${srcdir}"/no-check-dirs-permission.patch
   cp osdep-cygwin.c osdep-msys.c
 
   msg2 "Running autogen.sh"

--- a/tmux-git/no-check-dirs-permission.patch
+++ b/tmux-git/no-check-dirs-permission.patch
@@ -1,0 +1,16 @@
+diff --git tmux.c tmux.c
+index 62f8a80..d8ed280 100644
+--- tmux.c
++++ tmux.c
+@@ -149,7 +149,11 @@ makesocketpath(const char *label)
+ 		errno = ENOTDIR;
+ 		return (NULL);
+ 	}
++#ifdef __MSYS__
++	if (sb.st_uid != uid) {
++#else /* __MSYS__ */
+ 	if (sb.st_uid != uid || (sb.st_mode & S_IRWXO) != 0) {
++#endif /* __MSYS__ */
+ 		errno = EACCES;
+ 		return (NULL);
+ 	}


### PR DESCRIPTION
This patch belongs to issue #271.
It affects to only MSYS2 environment.