### PR TITLE
mosh: Update to 1.2.5

### DIFF
--- a/mosh/PKGBUILD
+++ b/mosh/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: James Ross-Gowan <rossymiles@gmail.com>
 
 pkgname=mosh
-pkgver=1.2.4
+pkgver=1.2.5
 pkgrel=1
 pkgdesc="Mobile shell, surviving disconnects with local echo and line editing"
 arch=('i686' 'x86_64')
@@ -9,22 +9,21 @@ url='http://mosh.mit.edu/'
 groups=('net-utils')
 license=('GPL3')
 depends=('protobuf' 'ncurses' 'zlib' 'libopenssl' 'openssh' 'perl')
-makedepends=('protobuf-devel' 'ncurses-devel' 'zlib-devel' 'openssl-devel')
+makedepends=('protobuf-devel' 'ncurses-devel' 'zlib-devel' 'openssl-devel' 'bash-completion')
 source=("http://${pkgname}.mit.edu/${pkgname}-${pkgver}.tar.gz")
-md5sums=('c2d918f4d91fdc32546e2e089f9281b2')
+sha256sums=('1af809e5d747c333a852fbf7acdbf4d354dc4bbc2839e3afe5cf798190074be3')
 options=(!emptydirs)
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   ./configure \
     --host=${CHOST} \
-    --prefix=/usr
+    --prefix=/usr \
+    --enable-completion
   make
 }
 
 package() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   make DESTDIR="$pkgdir" install
-  install -Dm644 "$srcdir/${pkgname}-${pkgver}/conf/bash_completion.d/$pkgname" \
-    "$pkgdir/usr/share/bash-completion/completions/$pkgname"
 }


### PR DESCRIPTION
Finally with xterm mouse support. The bash-completion script is now installed automatically.