### PR TITLE
python-mock: update naming to match other python 3.x packages in msys2

### DIFF
--- a/python-mock/PKGBUILD
+++ b/python-mock/PKGBUILD
@@ -3,12 +3,12 @@
 # Contributor: Felix Kaiser <felix.kaiser@fxkr.net>
 
 pkgbase=python-mock
-pkgname=(python2-mock python-mock)
+pkgname=(python2-mock python3-mock)
 pkgver=1.0.1
 pkgrel=1
 pkgdesc='Mocking and Patching Library for Testing'
 url='http://www.voidspace.org.uk/python/mock/'
-makedepends=('python2' 'python')
+makedepends=('python2' 'python3')
 license=('BSD')
 arch=('any')
 source=("http://pypi.python.org/packages/source/m/mock/mock-$pkgver.tar.gz")
@@ -25,8 +25,8 @@ build() {
   python2 setup.py build
 }
 
-package_python-mock() {
-depends=('python')
+package_python3-mock() {
+depends=('python3')
   cd "$srcdir/mock-$pkgver"
   python3 setup.py install --optimize=1 --root="$pkgdir"
   install -Dm644 LICENSE.txt "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE


### PR DESCRIPTION
I was too quick yesterday, the python 3 counterpart of mock should use python3-mock as pkgname.