### PR TITLE
addpkg: python-ply 3.6-1

### DIFF
--- a/python-ply/PKGBUILD
+++ b/python-ply/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Alexander Rødseth <rodseth@gmail.com>
+# Contributor: Marcin "avalan" Falkiewicz <avalatron@gmail.com>
+# Contributor: C Anthony Risinger <anthony@xtfx.me>
+
+pkgbase=python-ply
+pkgname=(python3-ply python2-ply)
+pkgver=3.6
+pkgrel=1
+pkgdesc='Implementation of lex and yacc parsing tools'
+arch=('any')
+url='http://www.dabeaz.com/ply/'
+license=('BSD')
+makedepends=('python3-setuptools' 'python2-setuptools')
+source=("${url}ply-$pkgver.tar.gz")
+sha256sums=('61367b9eb2f4b819f69ea116750305270f1df8859992c9e356d6a851f25a4b47')
+
+prepare() {
+  cp -a ${pkgbase#python-}-$pkgver{,-py2}
+}
+
+package_python3-ply() {
+  depends=('python3')
+
+  cd "${pkgbase#python-}-$pkgver"
+  python3 setup.py install --root="$pkgdir"
+}
+
+package_python2-ply() {
+  depends=('python2')
+
+  cd "${pkgbase#python-}-$pkgver-py2"
+  python2 setup.py install --root="$pkgdir"
+}
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Add as dependency in the python-cffi chain, preparing for pyopenssl and other cffi-based packages.