### PR TITLE
appveyor: Add build scripts.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+version: 1.0.{build}
+
+install:
+    - appveyor\msys2-prepare.cmd
+
+build_script:
+    - appveyor\msys2-wrapper.cmd appveyor\build.sh
+
+test: off

--- a/appveyor/PKGBUILD
+++ b/appveyor/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+pkgname=('xz' 'liblzma' 'liblzma-devel')
+pkgver=5.2.1
+pkgrel=1
+pkgdesc='Library and command line tools for XZ and LZMA compressed files'
+arch=('i686' 'x86_64')
+url='http://tukaani.org/xz/'
+license=('GPL' 'LGPL' 'custom')
+depends=('sh' 'libiconv' 'gettext')
+makedepends=('libiconv-devel' 'gettext-devel')
+options=('staticlibs')
+source=("http://tukaani.org/${pkgname}/${pkgname}-${pkgver}.tar.gz"{,.sig}
+        xz-5.0.5-msys2.patch)
+sha256sums=('b918b6648076e74f8d7ae19db5ee663df800049e187259faf5eb997a7b974681'
+            'SKIP'
+            '3d800a027f7f43b5553f3ad937f4fb31872c6cf0995b419922b5ea63316c1602')
+
+prepare() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+
+  patch -p1 -i ${srcdir}/xz-5.0.5-msys2.patch
+  autoreconf -ivf
+}
+
+build() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+
+  ./configure \
+    --build=${CHOST} \
+    --prefix=/usr \
+    --enable-shared \
+    --enable-static
+  make
+  make DESTDIR="${srcdir}/dest" install
+}
+
+check() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+  make check
+}
+
+package_xz() {
+  groups=('compression')
+  depends=('libiconv' 'libintl')
+
+  mkdir -p ${pkgdir}/usr/bin
+  cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
+  rm -f ${pkgdir}/usr/bin/*.dll
+  cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
+
+  #install -d -m755 ${pkgdir}/usr/share/licenses/xz/
+  #ln -sf /usr/share/doc/xz/COPYING ${pkgdir}/usr/share/licenses/xz/
+  #ln -sf /usr/share/licenses/common/GPL2/license.txt ${pkgdir}/usr/share/doc/xz/COPYING.GPLv2
+}
+
+package_liblzma() {
+  pkgdesc="Library for XZ and LZMA compressed files"
+  groups=('libraries')
+
+  mkdir -p ${pkgdir}/usr/bin
+  cp -f ${srcdir}/dest/usr/bin/*.dll ${pkgdir}/usr/bin/
+}
+
+package_liblzma-devel() {
+  pkgdesc="Liblzma headers and libraries"
+  groups=('development')
+  depends=("liblzma=${pkgver}" 'libiconv-devel' 'gettext-devel')
+  mkdir -p ${pkgdir}/usr
+  cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
+  cp -rf ${srcdir}/dest/usr/lib ${pkgdir}/usr/
+}

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=`pwd`
+popd > /dev/null
+
+cd $SCRIPTPATH
+
+set -x
+
+# cd to git repository root directory
+gittop=`git rev-parse --show-toplevel`
+cd $gittop
+
+# fetch first changed file
+changed=`git show --pretty="format:" --name-only | grep . | head -1`
+dir=`dirname $changed`
+if [ "$dir" = "." ]
+then
+    # self test
+    cd appveyor
+else
+    cd $dir
+fi
+
+pwd
+ls
+makepkg -f -s --noconfirm --skippgpcheck --noprogressbar

--- a/appveyor/msys2-prepare.cmd
+++ b/appveyor/msys2-prepare.cmd
@@ -1,0 +1,25 @@
+echo on
+choco install -y 7zip.commandline
+choco install -y axel
+set MSYS2_INSTALLER=msys2-base-i686-20150512.tar.xz
+axel http://sourceforge.net/projects/msys2/files/Base/i686/%MSYS2_INSTALLER% > nul
+7z x %MSYS2_INSTALLER% -oC:\ProgramData\msys2-base-i686.tar > nul
+7z x c:\ProgramData\msys2-base-i686.tar -oC:\ProgramData\ > nul
+
+set MSYSTEM=MSYS
+C:\ProgramData\msys32\usr\bin\bash -l -c "echo restart"
+
+C:\ProgramData\msys32\usr\bin\bash -l -c "curl http://repo.msys2.org/msys/i686/pacman-mirrors-20150619-1-any.pkg.tar.xz > pacman-mirrors-20150619-1-any.pkg.tar.xz"
+C:\ProgramData\msys32\usr\bin\bash -l -c "pacman -U --noconfirm pacman-mirrors-*"
+echo Server = http://repo.msys2.org/msys/$arch > C:\ProgramData\msys32\etc\pacman.d\mirrorlist.msys
+echo Server = http://repo.msys2.org/mingw/i686 > C:\ProgramData\msys32\etc\pacman.d\mirrorlist.mingw32
+echo Server = http://repo.msys2.org/mingw/x86_64 > C:\ProgramData\msys32\etc\pacman.d\mirrorlist.mingw64
+
+copy %~dp0\script_clean.pl C:\ProgramData\msys32\usr\bin
+C:\ProgramData\msys32\usr\bin\bash -l -c "pacman -Sy"
+C:\ProgramData\msys32\usr\bin\bash -l -c "pacman -S --needed --noconfirm msys2-runtime pacman bash"
+REM C:\ProgramData\msys32\usr\bin\bash -l -c "pacman -Su --noconfirm"
+C:\ProgramData\msys32\usr\bin\bash -l -c "pacman -S --needed --noconfirm msys2-devel base-devel git"
+C:\ProgramData\msys32\usr\bin\bash -l -c "git config --global user.name 'Appveyor Bot'"
+C:\ProgramData\msys32\usr\bin\bash -l -c "git config --global user.email 'Appveyor@dummy.com'"
+C:\ProgramData\msys32\usr\bin\bash -l -c "git config -l"

--- a/appveyor/msys2-wrapper.cmd
+++ b/appveyor/msys2-wrapper.cmd
@@ -1,0 +1,13 @@
+echo off
+set MSYSTEM=MSYS
+set id=%RANDOM%
+
+if "%1" == "-c" (
+    start C:\ProgramData\msys32\usr\bin\script -q -f -e -c '/usr/bin/bash.exe -l -c "echo $$ > /tmp/pid.%id% ; bash -e %* ; echo \$? > /tmp/exit_code.%id%"' /tmp/typescript.%id%
+) else (
+    start C:\ProgramData\msys32\usr\bin\script -q -f -e -c '/usr/bin/bash.exe -l -c "echo $$ > /tmp/pid.%id% ; bash -e `/usr/bin/cygpath -u \'%~f1\'` ; echo \$? > /tmp/exit_code.%id%"' /tmp/typescript.%id%
+)
+
+C:\ProgramData\msys32\usr\bin\bash -l -c "sleep 15"
+C:\ProgramData\msys32\usr\bin\bash -l -c "tail -F /tmp/typescript.%id% --pid=`cat /tmp/pid.%id%` | script_clean.pl"
+C:\ProgramData\msys32\usr\bin\bash -l -c "if test -f /tmp/exit_code.%id%; then cat /tmp/exit_code.%id%; (exit `cat /tmp/exit_code.%id%`); fi"

--- a/appveyor/script_clean.pl
+++ b/appveyor/script_clean.pl
@@ -1,0 +1,12 @@
+#!/usr/bin/perl
+
+while (<>) {
+    s/ \e[ #%()*+\-.\/]. |
+       \r | # Remove extra carriage returns also
+       (?:\e\[|\x9b) [ -?]* [@-~] | # CSI ... Cmd
+       (?:\e\]|\x9d) .*? (?:\e\\|[\a\x9c]) | # OSC ... (ST|BEL)
+       (?:\e[P^_]|[\x90\x9e\x9f]) .*? (?:\e\\|\x9c) | # (DCS|PM|APC) ... ST
+       \e.|[\x80-\x9f] //xg;
+       1 while s/[^\b][\b]//g;  # remove all non-backspace followed by backspace
+    print;
+}

--- a/appveyor/xz-5.0.5-msys2.patch
+++ b/appveyor/xz-5.0.5-msys2.patch
@@ -1,0 +1,112 @@
+diff -Naur xz-5.0.5/build-aux/compile xz-5.0.5-msys2/build-aux/compile
+--- xz-5.0.5/build-aux/compile	2013-06-30 17:17:56.000000000 +0400
++++ xz-5.0.5-msys2/build-aux/compile	2013-07-03 09:05:25.586914000 +0400
+@@ -53,7 +53,7 @@
+ 	  MINGW*)
+ 	    file_conv=mingw
+ 	    ;;
+-	  CYGWIN*)
++	  CYGWIN* | MSYS*)
+ 	    file_conv=cygwin
+ 	    ;;
+ 	  *)
+@@ -67,7 +67,7 @@
+ 	mingw/*)
+ 	  file=`cmd //C echo "$file " | sed -e 's/"\(.*\) " *$/\1/'`
+ 	  ;;
+-	cygwin/*)
++	cygwin/* | msys*/)
+ 	  file=`cygpath -m "$file" || echo "$file"`
+ 	  ;;
+ 	wine/*)
+diff -Naur xz-5.0.5/build-aux/config.guess xz-5.0.5-msys2/build-aux/config.guess
+--- xz-5.0.5/build-aux/config.guess	2013-06-30 17:17:56.000000000 +0400
++++ xz-5.0.5-msys2/build-aux/config.guess	2013-07-03 09:05:25.586914000 +0400
+@@ -866,6 +866,9 @@
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+ 	echo x86_64-unknown-cygwin
+ 	exit ;;
++    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
++	echo x86_64-unknown-msys
++	exit ;;
+     p*:CYGWIN*:*)
+ 	echo powerpcle-unknown-cygwin
+ 	exit ;;
+diff -Naur xz-5.0.5/build-aux/config.rpath xz-5.0.5-msys2/build-aux/config.rpath
+--- xz-5.0.5/build-aux/config.rpath	2013-06-30 17:17:38.000000000 +0400
++++ xz-5.0.5-msys2/build-aux/config.rpath	2013-07-03 09:11:10.618164000 +0400
+@@ -64,7 +64,7 @@
+           ;;
+       esac
+       ;;
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
++    mingw* | cygwin* | msys* | pw32* | os2* | cegcc*)
+       ;;
+     hpux9* | hpux10* | hpux11*)
+       wl='-Wl,'
+@@ -138,7 +138,7 @@
+ hardcode_minus_L=no
+ 
+ case "$host_os" in
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+@@ -188,7 +188,7 @@
+         ld_shlibs=no
+       fi
+       ;;
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+       # no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+@@ -332,7 +332,7 @@
+       ;;
+     bsdi[45]*)
+       ;;
+-    cygwin* | mingw* | pw32* | cegcc*)
++    cygwin* | msys* | mingw* | pw32* | cegcc*)
+       # When not using gcc, we currently assume that we are using
+       # Microsoft Visual C++.
+       # hardcode_libdir_flag_spec is actually meaningless, as there is
+@@ -523,7 +523,7 @@
+   bsdi[45]*)
+     library_names_spec='$libname$shrext'
+     ;;
+-  cygwin* | mingw* | pw32* | cegcc*)
++  cygwin* | msys* | mingw* | pw32* | cegcc*)
+     shrext=.dll
+     library_names_spec='$libname.dll.a $libname.lib'
+     ;;
+diff -Naur xz-5.0.5/configure.ac xz-5.0.5-msys2/configure.ac
+--- xz-5.0.5/configure.ac	2013-06-30 16:49:46.000000000 +0400
++++ xz-5.0.5-msys2/configure.ac	2013-07-03 09:05:25.711914000 +0400
+@@ -34,7 +34,7 @@
+ 
+ # We do some special things on Windows (32-bit or 64-bit) builds.
+ case $host_os in
+-	mingw* | cygwin*) is_w32=yes ;;
++	mingw* | cygwin* | msys*) is_w32=yes ;;
+ 	*)                is_w32=no ;;
+ esac
+ AM_CONDITIONAL([COND_W32], [test "$is_w32" = yes])
+@@ -44,7 +44,7 @@
+ # that symlinks don't have the .exe suffix. To make this work, we
+ # define LN_EXEEXT.
+ case $host_os in
+-	cygwin)  LN_EXEEXT= ;;
++	cygwin | msys)  LN_EXEEXT= ;;
+ 	*)       LN_EXEEXT='$(EXEEXT)' ;;
+ esac
+ AC_SUBST([LN_EXEEXT])
+@@ -283,7 +283,7 @@
+ 	case $host_os in
+ 		# Darwin should work too but only if not creating universal
+ 		# binaries. Solaris x86 could work too but I cannot test.
+-		linux* | *bsd* | mingw* | cygwin* | *djgpp*)
++		linux* | *bsd* | mingw* | cygwin* | msys* | *djgpp*)
+ 			case $host_cpu in
+ 				i?86)   enable_assembler=x86 ;;
+ 				x86_64) enable_assembler=x86_64 ;;


### PR DESCRIPTION
Hi Alexpux,

This is a proof-of-concept patch for using Appveyor to build MSYS2-packages.

I'll write an email soon to msys2-user mailing list to explain the details.

According to my limited tests so far, the Appveyor scripts works as expected, reports PASS when build passes, reports FAIL when build fails:

make: compiles fine but tests failed
https://ci.appveyor.com/project/fracting/msys2-packages/build/1.0.48 

python2: compiles fine but tests failed
https://ci.appveyor.com/project/fracting/msys2-packages/build/1.0.47

zlib: compiles fine and tests passed
https://ci.appveyor.com/project/fracting/msys2-packages/build/1.0.46

git: failed to compile test suite
https://ci.appveyor.com/project/fracting/msys2-packages/build/1.0.45

I'm open to any feedback and will continue improve the appveyor scripts as requested.