### PR TITLE
crosstool-ng patches 0003/0004 - Fix compile (issues: 9, 277)

### DIFF
--- a/crosstool-ng/0003-modify-kconfig-make-lintl.patch
+++ b/crosstool-ng/0003-modify-kconfig-make-lintl.patch
@@ -1,0 +1,28 @@
+diff -Naur crosstool-ng-1.21.0/kconfig/Makefile crosstool-ng-1.21.0.new/kconfig/Makefile
+--- crosstool-ng-1.21.0/kconfig/Makefile	2015-09-03 09:45:51.840310400 +0200
++++ crosstool-ng-1.21.0.new/kconfig/Makefile	2015-09-03 10:39:24.252670900 +0200
+@@ -35,20 +35,21 @@
+ conf_OBJ = $(patsubst %.c,%.o,$(conf_SRC))
+ conf_DEP = $(patsubst %.o,%.dep,$(conf_OBJ))
+ $(conf_OBJ) $(conf_DEP): CFLAGS += $(INTL_CFLAGS)
++conf: LDFLAGS += -lintl
+ 
+ # What's needed to build 'mconf'
+ mconf_SRC = mconf.c
+ mconf_OBJ = $(patsubst %.c,%.o,$(mconf_SRC))
+ mconf_DEP = $(patsubst %.c,%.dep,$(mconf_SRC))
+ $(mconf_OBJ) $(mconf_DEP): CFLAGS += $(NCURSES_CFLAGS) $(INTL_CFLAGS)
+-mconf: LDFLAGS += $(NCURSES_LDFLAGS)
++mconf: LDFLAGS += -lintl $(NCURSES_LDFLAGS)
+ 
+ # What's needed to build 'nconf'
+ nconf_SRC = nconf.c nconf.gui.c
+ nconf_OBJ = $(patsubst %.c,%.o,$(nconf_SRC))
+ nconf_DEP = $(patsubst %.c,%.dep,$(nconf_SRC))
+-$(nconf_OBJ) $(nconf_DEP): CFLAGS += $(INTL_CFLAGS) -I/usr/include/ncurses
+-nconf: LDFLAGS += -lmenuw -lpanelw -lncursesw
++$(nconf_OBJ) $(nconf_DEP): CFLAGS += -I/usr/include/ncurses/ $(INTL_CFLAGS)
++nconf: LDFLAGS += -lintl -lmenuw -lpanelw -lncursesw
+ 
+ # Under Cygwin, we need to auto-import some libs (which ones, exactly?)
+ # for mconf and nconf to lin properly.

--- a/crosstool-ng/0004-kconfig-nconf-fix-compile-with-ncurses-reentrant-API.patch
+++ b/crosstool-ng/0004-kconfig-nconf-fix-compile-with-ncurses-reentrant-API.patch
@@ -1,0 +1,16 @@
+diff -Naur crosstool-ng-1.21.0/kconfig/nconf.c crosstool-ng-1.21.0.new/kconfig/nconf.c
+--- crosstool-ng-1.21.0/kconfig/nconf.c	2015-05-25 21:47:17.000000000 +0200
++++ crosstool-ng-1.21.0.new/kconfig/nconf.c	2015-09-03 11:27:08.442172100 +0200
+@@ -1518,7 +1518,11 @@
+ 	}
+ 
+ 	notimeout(stdscr, FALSE);
+-	ESCDELAY = 1;
++#if NCURSES_REENTRANT
++	set_escdelay(1);
++#else
++ 	ESCDELAY = 1;
++#endif	
+ 
+ 	/* set btns menu */
+ 	curses_menu = new_menu(curses_menu_items);

--- a/crosstool-ng/PKGBUILD
+++ b/crosstool-ng/PKGBUILD
@@ -15,16 +15,21 @@ depends=("ncurses" "libintl")
 options=('staticlibs' 'strip')
 source=("http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-${pkgver}.tar.xz"
         "0001-Modify-config-to-support-correct-Mingw64-Triplet-Nam.patch"
-        "0002-use-wide-versions-of-libs-for-nconf.patch")
+        "0002-use-wide-versions-of-libs-for-nconf.patch"
+		"0003-modify-kconfig-make-lintl.patch"
+		"0004-kconfig-nconf-fix-compile-with-ncurses-reentrant-API.patch")
 md5sums=('ee969dff8783605cd4acf4840113a119'
          'a893266875be8b7286e407a0df53152a'
-         '4a2dd7faa9198e66f83907cb6ef53412')
+         '4a2dd7faa9198e66f83907cb6ef53412'
+		 'fd46a1565c20ecb3ba297903247196d9'
+		 '9af4f3da31f42b731f8daf1431a0a0fb')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-Modify-config-to-support-correct-Mingw64-Triplet-Nam.patch"
   patch -p1 -i "${srcdir}/0002-use-wide-versions-of-libs-for-nconf.patch"
-
+  patch -p1 -i "${srcdir}/0003-modify-kconfig-make-lintl.patch"
+  patch -p1 -i "${srcdir}/0004-kconfig-nconf-fix-compile-with-ncurses-reentrant-API.patch"
   ./bootstrap
 }
 


### PR DESCRIPTION

Made a pull request for the open issues 9 and 277
https://github.com/diorcety/crosstool-ng/issues/9
https://github.com/Alexpux/MSYS2-packages/issues/277

The patches are based on:
http://cygwin.com/ml/cygwin/2012-06/msg00221/0004-kconfig-nconf-fix-compile-with-ncurses-reentrant-API.patch
https://sourceware.org/ml/crossgcc/2012-05/msg00012.html