### PR TITLE
bash-completion: avoid unnecessary tilde expansion

### DIFF
--- a/bash-completion/PKGBUILD
+++ b/bash-completion/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=bash-completion
 pkgver=2.1
-pkgrel=5
+pkgrel=6
 pkgdesc="Programmable completion for the bash shell"
 arch=('any')
 url="http://bash-completion.alioth.debian.org/"
@@ -15,8 +15,7 @@ source=(http://bash-completion.alioth.debian.org/files/${pkgname}-${pkgver}.tar.
         quote_readline_by_ref_fixes.patch)
 md5sums=('4e2a9f11a4042a38ee79ddcd048e8b9e'
          'f524a2d082fe5f799ab262c91a0cd507'
-         '63f32c5c27d883d316d185bc00b0fdd4')
-
+         'fddc94f7c6bfe6d011d923ff62d4d839')
 prepare() {
   cd ${pkgname}-${pkgver}
   patch -p1 -i ${srcdir}/words_bad_array_subscript.patch

--- a/bash-completion/quote_readline_by_ref_fixes.patch
+++ b/bash-completion/quote_readline_by_ref_fixes.patch
@@ -11,9 +11,9 @@
 +    elif [[ $1 == \'* ]]; then
          # Leave out first character
          printf -v $2 %s "${1:1}"
-+    elif [[ $1 == ~* ]]; then
++    elif [[ $1 == \~* ]]; then
 +        # avoid escaping first ~
-+        printf -v $2 ~%q "${1:1}"
++        printf -v $2 \~%q "${1:1}"
      else
          printf -v $2 %q "$1"
      fi


### PR DESCRIPTION
When connected to an Active Directory (a variant of LDAP), tab completion
becomes very slow because the tilde is expanded all the time, even if
completing paths that do not contain a tilde at all. This developer
observed delays of several seconds at a time.

This is completely unnecessary, so let's do not do that.

The patch was provided by Ove Risberg with a bug report to the original
bash-completion project:

	https://bugs.launchpad.net/ubuntu/+source/bash-completion/+bug/1390061

Since it fixes code introduced by another add-on patch, that add-on patch
was modified instead of adding yet another patch.

This fixes https://github.com/git-for-windows/git/issues/377

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>