### PR TITLE
Add the docx2txt Package

### DIFF
--- a/docx2txt/PKGBUILD
+++ b/docx2txt/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Matthias Aßhauer <mha1993@live.de>
+
+_realname=docx2txt
+
+pkgname=("${_realname}")
+pkgver=1.4
+pkgrel=1
+pkgdesc="docx2txt is a perl based command line utility to convert Microsoft Office(Tm) Docx documents to equivalent Text documents."
+arch=('i686' 'x86_64')
+license=('GPL3+')
+url="http://${_realname}.sourceforge.net/"
+source=("http://sourceforge.net/projects/${_realname}/files/${_realname}/v${pkgver}/${_realname}-${pkgver}.tgz/download")
+sha1sums=('a23f83ec5e1d479888815255e81063c02c932c2f')
+provides=('${_realname}')
+depends=('perl' 'unzip')
+
+package() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  make BINDIR=$pkgdir/usr/bin installbin
+  make CONFIGDIR=$pkgdir/etc installconfig
+  mv -f $pkgdir/usr/bin/docx2txt.sh $pkgdir/usr/bin/docx2txt
+}


### PR DESCRIPTION
docx2txt is a perl based conversion tool to convert docx files to plain
text. It simplifies comparing the content of docx files a lot.

Its usage is simple:

	docx2txt.pl [infile.docx|-|-h] [outfile.txt|-]
	docx2txt.pl < infile.docx
	docx2txt.pl < infile.docx > outfile.txt

Signed-off-by: Matthias Aßhauer <mha1993@live.de>
Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>