### PR TITLE
Support ~/.vimrc with DOS line endings

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -11,7 +11,7 @@ license=('custom:vim')
 url="http://www.vim.org"
 depends=('ncurses')
 groups=('editors')
-makedepends=('gawk' 'perl' 'python2' 'python3' 'ruby' 'libiconv')
+makedepends=('gawk' 'perl' 'python2' 'python3' 'ruby' 'libiconv' 'ncurses-devel' 'libcrypt-devel')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgver}.tar.gz
         'dot.vimrc'
         '7.3-cygwin-mouse.patch'

--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -5,7 +5,7 @@ _topver=7.4
 _patchlevel=865
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 license=('custom:vim')
 url="http://www.vim.org"
@@ -18,6 +18,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         '7.3-virc.patch'
         '7.3-cygwin-python-dyn.patch'
         'pretend-cygwin-msys.patch'
+        'accept-crlf.patch'
         'vim-completion')
 md5sums=('88ad325445b1599b19f9da3e91bdd0c5'
          'b18bd005832117243727e9fef1b45691'
@@ -25,6 +26,7 @@ md5sums=('88ad325445b1599b19f9da3e91bdd0c5'
          'e776f485d8f027050ff040120acb8a86'
          '88ab80d81af8e88cf80d21b2796ec94d'
          'a5d13302787cd004ae188b69e353035d'
+         '799e210945d2bcbd1140af8b3221c224'
          '87fe7821e180647f3bf48ed099a22b83')
 
 prepare() {
@@ -37,6 +39,7 @@ prepare() {
   patch -p2 -i ${srcdir}/7.3-virc.patch
   patch -p2 -i ${srcdir}/7.3-cygwin-python-dyn.patch
   patch -p1 -i ${srcdir}/pretend-cygwin-msys.patch
+  patch -p1 -i ${srcdir}/accept-crlf.patch
 
   # define the place for the global (g)vimrc file (set to /etc/vimrc)
   #sed -i 's|^.*\(#define SYS_.*VIMRC_FILE.*"\) .*$|\1|' \

--- a/vim/accept-crlf.patch
+++ b/vim/accept-crlf.patch
@@ -1,0 +1,109 @@
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Tue, 15 Sep 2015 12:57:37 +0200
+Subject: [PATCH] Always accept CR/LF in MSys2
+
+Since we are running on Windows, we have to expect that at least some
+files or input use DOS line endings, still.
+
+It is okay, of course, to behave like Unix vim otherwise, e.g. to create
+LF-only files by default.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ src/eval.c     |  2 +-
+ src/ex_cmds2.c | 10 +++++-----
+ src/fileio.c   |  2 +-
+ src/quickfix.c |  2 +-
+ 4 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/eval.c b/src/eval.c
+index 9a590c7..ee40e1e 100644
+--- a/src/eval.c
++++ b/src/eval.c
+@@ -19105,7 +19105,7 @@ get_cmd_output_as_rettv(argvars, rettv, retlist)
+ 	    }
+ 	}
+ #else
+-# ifdef USE_CRNL
++# if defined(__MSYS__) || defined(USE_CRNL)
+ 	/* translate <CR><NL> into <NL> */
+ 	if (res != NULL)
+ 	{
+diff --git a/src/ex_cmds2.c b/src/ex_cmds2.c
+index 30f9e9d..c2d6e0f 100644
+--- a/src/ex_cmds2.c
++++ b/src/ex_cmds2.c
+@@ -3017,7 +3017,7 @@ struct source_cookie
+     FILE	*fp;		/* opened file for sourcing */
+     char_u      *nextline;      /* if not NULL: line that was read ahead */
+     int		finished;	/* ":finish" used */
+-#if defined(USE_CRNL) || defined(USE_CR)
++#if defined(__MSYS__) || defined(USE_CRNL) || defined(USE_CR)
+     int		fileformat;	/* EOL_UNKNOWN, EOL_UNIX or EOL_DOS */
+     int		error;		/* TRUE if LF found after CR-LF */
+ #endif
+@@ -3234,7 +3234,7 @@ do_source(fname, check_other, is_vimrc)
+     else if (is_vimrc == DOSO_GVIMRC)
+ 	vimrc_found(fname_exp, (char_u *)"MYGVIMRC");
+ 
+-#ifdef USE_CRNL
++#if defined(__MSYS__) || defined(USE_CRNL)
+     /* If no automatic file format: Set default to CR-NL. */
+     if (*p_ffs == NUL)
+ 	cookie.fileformat = EOL_DOS;
+@@ -3719,7 +3719,7 @@ get_one_sourceline(sp)
+     int			len;
+     int			c;
+     char_u		*buf;
+-#ifdef USE_CRNL
++#if defined(__MSYS__) || defined(USE_CRNL)
+     int			has_cr;		/* CR-LF found */
+ #endif
+ #ifdef USE_CR
+@@ -3754,7 +3754,7 @@ get_one_sourceline(sp)
+ 							      sp->fp) == NULL)
+ 		break;
+ 	len = ga.ga_len + (int)STRLEN(buf + ga.ga_len);
+-#ifdef USE_CRNL
++#if defined(__MSYS__) || defined(USE_CRNL)
+ 	/* Ignore a trailing CTRL-Z, when in Dos mode.	Only recognize the
+ 	 * CTRL-Z by its own, or after a NL. */
+ 	if (	   (len == 1 || (len >= 2 && buf[len - 2] == '\n'))
+@@ -3803,7 +3803,7 @@ get_one_sourceline(sp)
+ 
+ 	if (len >= 1 && buf[len - 1] == '\n')	/* remove trailing NL */
+ 	{
+-#ifdef USE_CRNL
++#if defined(__MSYS__) || defined(USE_CRNL)
+ 	    has_cr = (len >= 2 && buf[len - 2] == '\r');
+ 	    if (sp->fileformat == EOL_UNKNOWN)
+ 	    {
+diff --git a/src/fileio.c b/src/fileio.c
+index 0f3f148..016f15d 100644
+--- a/src/fileio.c
++++ b/src/fileio.c
+@@ -5208,7 +5208,7 @@ msg_add_fileformat(eol_type)
+ 	return TRUE;
+     }
+ #endif
+-#if defined(USE_CRNL) || defined(USE_CR)
++#if defined(__MSYS__) || defined(USE_CRNL) || defined(USE_CR)
+     if (eol_type == EOL_UNIX)
+     {
+ 	STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"));
+diff --git a/src/quickfix.c b/src/quickfix.c
+index 7243a0c..3278bd7 100644
+--- a/src/quickfix.c
++++ b/src/quickfix.c
+@@ -570,7 +570,7 @@ qf_init_ext(qi, efile, buf, tv, errorformat, newlist, lnumfirst, lnumlast,
+ 
+ 	if ((efmp = vim_strrchr(IObuff, '\n')) != NULL)
+ 	    *efmp = NUL;
+-#ifdef USE_CRNL
++#if defined(__MSYS__) || defined(USE_CRNL)
+ 	if ((efmp = vim_strrchr(IObuff, '\r')) != NULL)
+ 	    *efmp = NUL;
+ #endif
+-- 
+2.5.2
+


### PR DESCRIPTION
It was noticed in https://github.com/git-for-windows/git/issues/272 and https://github.com/git-for-windows/git/issues/364 that MSys2's `vim` has problems when the user's `$HOME/.vimrc` contains DOS line endings. This is quite common when MSys2 is configured with the regular Windows home directory as `$HOME`.

It's easy to support, so let's do that.