### PR TITLE
Fix winpty's locale

### DIFF
--- a/winpty-git/0004-Set-the-appropriate-locale.patch
+++ b/winpty-git/0004-Set-the-appropriate-locale.patch
@@ -1,0 +1,36 @@
+From 0634eb9e2bf47b028988e1932fa444f56f49332a Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 23 Sep 2015 15:32:35 +0000
+Subject: [PATCH 4/4] Set the appropriate locale
+
+By calling `setlocale(LC_ALL, "");`, we give the user a chance to
+override the ASCII-only default so that non-ASCII arguments are
+converted into UTF-16 properly, which is required to pass them
+correctly to the actual Win32 executable.
+
+This is necessary because POSIX dictates that we start up with the C
+locale, ignoring all environment variables, until that `setlocale()`
+call.
+
+This fixes https://github.com/git-for-windows/git/issues/412
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ unix-adapter/main.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/unix-adapter/main.cc b/unix-adapter/main.cc
+index 80d01a2..14fabbf 100644
+--- a/unix-adapter/main.cc
++++ b/unix-adapter/main.cc
+@@ -344,6 +344,7 @@ int main(int argc, char *argv[])
+         return 0;
+     }
+ 
++    setlocale(LC_ALL, "");
+     setupWin32Environment();
+ 
+     winsize sz;
+-- 
+2.5.2
+

--- a/winpty-git/PKGBUILD
+++ b/winpty-git/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=winpty
 pkgname="${_realname}-git"
 _ver_base=1.1.1
-pkgver=1.1.1.148.47a69d0
-pkgrel=3
+pkgver=1.1.1.160.0c1e064
+pkgrel=1
 pkgdesc="A Windows software package providing an interface similar to a Unix pty-master for communicating with Windows console programs"
 arch=('i686' 'x86_64')
 url="https://github.com/rprichard/winpty"

--- a/winpty-git/PKGBUILD
+++ b/winpty-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=winpty
 pkgname="${_realname}-git"
 _ver_base=1.1.1
 pkgver=1.1.1.148.47a69d0
-pkgrel=2
+pkgrel=3
 pkgdesc="A Windows software package providing an interface similar to a Unix pty-master for communicating with Windows console programs"
 arch=('i686' 'x86_64')
 url="https://github.com/rprichard/winpty"
@@ -19,12 +19,14 @@ options=('staticlibs' 'strip')
 source=("${_realname}"::"git+https://github.com/rprichard/winpty.git"
         "0001-Added-Support-for-MSYS2.patch"
         "0002-Add-support-for-conversion-of-all-argv-path-args.patch"
-        "0003-rename-console.exe-to-winpty.exe-for-mintty-unicode-.patch")
+        "0003-rename-console.exe-to-winpty.exe-for-mintty-unicode-.patch"
+        "0004-Set-the-appropriate-locale.patch")
 
 md5sums=('SKIP'
          '31edad9a6ca01c38e8e63b680bf456f1'
          '55c27b707c559e20ef21079c5d84e49b'
-         'a86ac650f9893ed1c6a606b803e684aa')
+         'a86ac650f9893ed1c6a606b803e684aa'
+         '122508a916cbffaf98027e9908909877')
 
 
 pkgver() {
@@ -39,7 +41,7 @@ prepare() {
   git am "$srcdir/0001-Added-Support-for-MSYS2.patch"
   git am "$srcdir/0002-Add-support-for-conversion-of-all-argv-path-args.patch"
   git am "$srcdir/0003-rename-console.exe-to-winpty.exe-for-mintty-unicode-.patch"
-
+  git am "$srcdir/0004-Set-the-appropriate-locale.patch"
 }
 
 build() {


### PR DESCRIPTION
This is necessary to deal with non-ASCII command-line parameters correctly.

I also submitted this as a [Pull Request to winpty](https://github.com/rprichard/winpty/pull/37) but I figured it would not hurt to have it in MSys2 as soon as possible.

This fixes https://github.com/git-for-windows/git/issues/412