### PR TITLE
Switch git-flow to use the AVH edition

### DIFF
--- a/git-flow/PKGBUILD
+++ b/git-flow/PKGBUILD
@@ -2,14 +2,14 @@
 
 _realname=git-flow
 pkgname=("${_realname}")
-pkgver=0.4.1.108.g15aab26
+pkgver=1.8.0.58.gd441201
 pkgrel=1
-pkgdesc="Git extensions to provide high-level repository operations for Vincent Driessen's branching model"
+pkgdesc="Git extensions to provide high-level repository operations for Vincent Driessen's branching model (AVH edition)"
 arch=('i686' 'x86_64')
 license=('BSD')
 depends=('git' 'util-linux')
-url="http://nvie.com/posts/a-successful-git-branching-model/"
-source=("${_realname}"::"git+https://github.com/nvie/gitflow.git#branch=develop")
+url="https://github.com/petervanderdoes/gitflow-avh"
+source=("${_realname}"::"git+https://github.com/petervanderdoes/gitflow-avh.git#branch=develop")
 sha1sums=('SKIP')
 
 pkgver() {
@@ -24,18 +24,6 @@ pkgver() {
 
   git describe --tags |
   sed -e 's/^v//' -e 'y/-/./'
-}
-
-prepare () {
-  cd "${srcdir}/${_realname}"
-
-  git submodule update --init
-
-  # Make sure that gitflow-shFlags is handled properly
-  test true = "$(git config core.symlinks)" || {
-    git config core.symlinks true
-    git reset --hard
-  }
 }
 
 package() {


### PR DESCRIPTION
The https://github.com/nvie/git-flow repository appears to be
abandoned. The common wisdom is that Peter van der Does' AVH edition
is the legitimate successor:

	https://github.com/petervanderdoes/gitflow-avh

This fixes issue https://github.com/git-for-windows/git/issues/416

Original-patch-by: Robert Dailey <rcdailey@gmail.com>
Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>