### PR TITLE
Fix futureware mirror

### DIFF
--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -6,5 +6,5 @@
 ## msys2.org
 Server = http://repo.msys2.org/mingw/i686
 Server = http://downloads.sourceforge.net/project/msys2/REPOS/MINGW/i686
-Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw32
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/i686/
 

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -6,5 +6,5 @@
 ## msys2.org
 Server = http://repo.msys2.org/mingw/x86_64
 Server = http://downloads.sourceforge.net/project/msys2/REPOS/MINGW/x86_64
-Server = https://www2.futureware.at/~nickoe/msys2-mirror/mingw64
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/x86_64/
 

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -6,5 +6,5 @@
 ## msys2.org
 Server = http://repo.msys2.org/msys/$arch
 Server = http://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/$arch
-Server = https://www2.futureware.at/~nickoe/msys2-mirror/msys2-$arch
+Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
 


### PR DESCRIPTION
Current locations are broken in 3 ways:

    $ wget --spider --no-check https://www2.futureware.at/~nickoe/msys2-mirror/x86_64/mingw64
    WARNING: The certificate of ‘www2.futureware.at’ is not trusted.
    WARNING: The certificate of ‘www2.futureware.at’ hasn't got a known issuer.
    HTTP request sent, awaiting response... 404 Not Found
    Remote file does not exist -- broken link!!!

1. Bad certificates - links need to be HTTP until this is fixed

2. Location has changed - now `x86_64` rather than `mingw64`

3. Final `/` is needed to avoid a redirect:

        $ wget --spider http://www2.futureware.at/~nickoe/msys2-mirror/x86_64
        HTTP request sent, awaiting response... 301 Moved Permanently
        Location: http://www2.futureware.at/~nickoe/msys2-mirror/x86_64/ [following]