### PR TITLE
winpty-git: Restore path mangling of all command-line arguments

### DIFF
--- a/winpty-git/0002-Add-support-for-conversion-of-all-argv-path-args.patch
+++ b/winpty-git/0002-Add-support-for-conversion-of-all-argv-path-args.patch
@@ -1,0 +1,25 @@
+From 2f9c59cf632f0b01b81757d354162d2570f1d5c4 Mon Sep 17 00:00:00 2001
+From: David Macek <david.macek.0@gmail.com>
+Date: Thu, 8 Oct 2015 21:38:59 +0200
+Subject: [PATCH] Add support for conversion of all argv path args
+
+---
+ unix-adapter/main.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unix-adapter/main.cc b/unix-adapter/main.cc
+index 7e75d28..6c34fd9 100644
+--- a/unix-adapter/main.cc
++++ b/unix-adapter/main.cc
+@@ -377,7 +377,7 @@ int main(int argc, char *argv[])
+         std::vector<std::string> argVector;
+         argVector.push_back(convertPosixPathToWin(argv[1]));
+         for (int i = 2; i < argc; ++i)
+-            argVector.push_back(argv[i]);
++            argVector.push_back(convertPosixPathToWin(argv[i]));
+         std::string cmdLine = argvToCommandLine(argVector);
+         wchar_t *cmdLineW = heapMbsToWcs(cmdLine.c_str());
+         int ret = winpty_start_process(winpty,
+-- 
+2.5.2
+

--- a/winpty-git/PKGBUILD
+++ b/winpty-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=winpty
 pkgname="${_realname}-git"
 _ver_base=1.1.1
 pkgver=1.1.1.184.db12b07
-pkgrel=1
+pkgrel=2
 pkgdesc="A Windows software package providing an interface similar to a Unix pty-master for communicating with Windows console programs"
 arch=('i686' 'x86_64')
 url="https://github.com/rprichard/winpty"
@@ -17,9 +17,11 @@ conflicts=("${_realname}")
 options=('staticlibs' 'strip')
 
 source=("${_realname}"::"git+https://github.com/rprichard/winpty.git"
+        "0002-Add-support-for-conversion-of-all-argv-path-args.patch"
         "0003-rename-console.exe-to-winpty.exe-for-mintty-unicode-.patch")
 
 md5sums=('SKIP'
+         'e352e89e98422fcdbc0182b99a22dccf'
          'a86ac650f9893ed1c6a606b803e684aa')
 
 
@@ -31,6 +33,7 @@ pkgver() {
 prepare() {
   cd "${srcdir}/${_realname}"
 
+  git am "$srcdir/0002-Add-support-for-conversion-of-all-argv-path-args.patch"
   git am "$srcdir/0003-rename-console.exe-to-winpty.exe-for-mintty-unicode-.patch"
 }
 


### PR DESCRIPTION
In 35510397c6e92845dbad8cdb215d3bef67dc2529, patch `0002-Add-support-for-conversion-of-all-argv-path-args.patch` was removed because it was thought to be superseded by an upstream commit[1], but that was actually only one part of the patch. This commit restores the patch minus the upstreamed part. Fixes #360.

[1] https://github.com/rprichard/winpty/commit/2ecc596f8b191b8b8cd90dfffba162985d3ed0e3