### PR TITLE
mutt: New Package (Version 1.5.24)

### DIFF
--- a/mutt/PKGBUILD
+++ b/mutt/PKGBUILD
@@ -1,0 +1,48 @@
+# $Id$
+# Maintainer: Felix Huettner <huettner94@gmx.de>
+
+pkgname=mutt
+pkgver=1.5.24
+pkgrel=1
+pkgdesc='Small but very powerful text-based mail client'
+url='http://www.mutt.org/'
+license=('GPL')
+backup=('etc/Muttrc')
+arch=('i686' 'x86_64')
+depends=('libgpgme' 'libsasl' 'libgdbm' 'ncurses' 'openssl' 'libidn')
+makedepends=('libgpgme-devel' 'libsasl-devel' 'libgdbm-devel' 'ncurses-devel' 'openssl-devel' 'libidn-devel')
+source=("http://ftp.mutt.org/pub/mutt/${pkgname}-${pkgver}.tar.gz"{,.asc})
+sha1sums=('38a2da5eb01ff83a90a2caee28fa2e95dbfe6898' 'SKIP')
+validpgpkeys=('8975A9B33AA37910385C5308ADEF768480316BDA')
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  ./configure \
+    --prefix=/usr \
+    --sysconfdir=/etc \
+    --enable-gpgme \
+    --enable-pop \
+    --enable-imap \
+    --enable-smtp \
+    --enable-hcache \
+    --with-curses=/usr \
+    --with-regex \
+    --with-gss=/usr \
+    --with-ssl=/usr \
+    --with-sasl \
+    --with-idn \
+    --with-gdbm \
+    --with-mailpath=/var/spool/mail
+
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+
+  rm "${pkgdir}"/etc/mime.types{,.dist}
+  rm "${pkgdir}"/usr/bin/{flea,muttbug}
+  rm "${pkgdir}"/usr/share/man/man1/{flea,muttbug}.1
+  install -Dm644 contrib/gpg.rc "${pkgdir}"/etc/Muttrc.gpg.dist
+}


### PR DESCRIPTION
Created a new Package for mutt
The PKGBUILD is mostly the same as the one from ArchLinux (https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/mutt)

The most important difference is the `--with-mailpath=/var/spool/mail`
The configure Script searches if a valid mail path exists. It looks for the following four directories:
1. `/var/mail`
2. `/var/spool/mail`
3. `/usr/spool/mail`
4. `/usr/mail`
The first existing directory will be used. If none of these directories exist you need to specify one with the `--with-mailpath` option. 
I choose `/var/spool/mail` because it made the most sense to me.