### PR TITLE
Run update-core as a shell function instead of its own shell

### DIFF
--- a/filesystem/profile
+++ b/filesystem/profile
@@ -135,6 +135,12 @@ export PATH MANPATH INFOPATH PKG_CONFIG_PATH USER TMP TEMP PRINTER HOSTNAME PS1 
 export TERM=xterm-256color
 unset PATH_SEPARATOR
 
+# This allows update-core to change PS1 and PROMPT_COMMAND
+# for the user's shell, which avoids a crash.
+update-core() {
+  source /usr/bin/update-core
+}
+
 if [ "$MAYBE_FIRST_START" = "true" ]; then
   sh /usr/bin/regen-info.sh
   


### PR DESCRIPTION
This is the second part of https://github.com/Alexpux/MSYS2-pacman/pull/20

It fixes a crash that happens if $PS1 runs a subcommand.