### PR TITLE
emacs msys2 version for posix tools user

### DIFF
--- a/emacs-git/PKGBUILD
+++ b/emacs-git/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Ricky <rickleaf.wu@gmail.com>
+
+_realname="emacs"
+pkgname="emacs-git"
+pkgver=r123396.5c81fd5
+pkgrel=1
+pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
+url="http://www.gnu.org/software/${_realname}/"
+license=('GPL3')
+arch=('any')
+depends=('ncurses')
+groups=('editors')
+makedepends=('gawk' 'perl' 'python2' 'python3' 'ruby' 'libiconv' 'ncurses-devel' 'libcrypt-devel')
+options=('strip')
+source=("${_realname}"::"git://git.savannah.gnu.org/${_realname}.git"
+        'image.c.diff'
+        'lread.c.diff'
+        'configure.ac.diff')
+sha256sums=('SKIP'
+            '4571d45ec26fd556e73a70bb0ab0a2a8fa1efc5e3b3c5b472ab68bb7dc9bf52c'
+            'b9db1b7d939301d0fedf52db6ac055f7265ee5bc0c3c757e394700ca39577b7f')
+
+pkgver() {
+  cd "${_realname}"
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${_realname}"
+  patch --binary --forward -p0 < "${srcdir}/image.c.diff"
+  patch --binary --forward -p0 < "${srcdir}/lread.c.diff"
+  patch --binary --forward -p0 < "${srcdir}/configure.ac.diff"
+  ./autogen.sh
+}
+
+build() {
+	
+  cd "${srcdir}/${_realname}"
+
+  CPPFLAGS="-DNDEBUG"
+  CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
+  LDFLAGS="-s -Wl,-s"
+  ./configure \
+    --prefix=/usr \
+    --build="${CHOST}" \
+    --with-wide-int="yes" \
+    --with-w32="yes" \
+    --with-sound="yes" \
+    --with-file-notification="yes" \
+    --without-gpm \
+    --without-gconf \
+    --without-gsettings \
+    --without-selinux
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/${_realname}
+  make DESTDIR="${pkgdir}" install
+  rm -f "${pkgdir}/usr/bin/ctags.exe"
+  rm -f "${pkgdir}/usr/share/man/man1/ctags.1.gz"
+  rm -f "${pkgdir}/usr/share/info/info.info.gz"
+
+  local dir="${pkgdir}/usr/share/${_realname}"
+        dir="${dir}/$(ls -1 ${dir} | grep -E '([0-9]+\.[0-9]+)(\.[0-9]+)?')/src"
+
+  mkdir -p "${dir}"
+  cd "${srcdir}/${_realname}/src"
+  cp *.c *.h *.m "${dir}"
+  
+}
+
+# TODO:
+# Patch `shell-file-name' default in the C source code similarly to
+# `source-directory'.

--- a/emacs-git/configure.ac.diff
+++ b/emacs-git/configure.ac.diff
@@ -1,0 +1,14 @@
+--- configure.ac	2015-11-20 09:45:52.610474600 +0800
++++ configure.ac.ricky	2015-11-20 09:46:40.278362400 +0800
+@@ -619,6 +619,11 @@ case "${canonical}" in
+   *-*-cygwin )
+     opsys=cygwin
+   ;;
++  
++  ## MSYS2 ports
++  *-*-msys )
++    opsys=cygwin
++  ;;
+ 
+   ## HP 9000 series 700 and 800, running HP/UX
+   hppa*-hp-hpux10.2* )

--- a/emacs-git/image.c.diff
+++ b/emacs-git/image.c.diff
@@ -1,0 +1,11 @@
+--- src/image.c.orig	2014-10-15 14:18:29.088716000 +0200
++++ src/image.c	2014-10-15 15:54:12.407522800 +0200
+@@ -7862,7 +7862,7 @@
+   };
+ 
+ #if defined HAVE_NTGUI && defined WINDOWSNT
+-static bool init_imagemagick_functions (void);
++#define init_imagemagick_functions NULL
+ #else
+ #define init_imagemagick_functions NULL
+ #endif

--- a/emacs-git/lread.c.diff
+++ b/emacs-git/lread.c.diff
@@ -1,0 +1,15 @@
+--- src/lread.c.orig	2014-11-04 20:29:22.129549000 +0100
++++ src/lread.c	2014-11-04 22:33:07.346414100 +0100
+@@ -4351,6 +4351,12 @@
+             } /* Vinstallation_directory != Vsource_directory */
+ 
+         } /* if Vinstallation_directory */
++      else
++        {
++          Vsource_directory
++            = Fexpand_file_name (build_string ("../"),
++                                 Fcar (decode_env_path (0, PATH_DATA, 0)));
++        }
+     }
+   else                          /* !initialized */
+     {

--- a/emacs-git/msys.diff
+++ b/emacs-git/msys.diff
@@ -1,0 +1,14 @@
+--- configure.ac	2015-11-19 15:21:41.428015900 +0800
++++ configure_ricky.ac	2015-11-19 13:59:25.697907400 +0800
+@@ -619,6 +619,11 @@ case "${canonical}" in
+   *-*-cygwin )
+     opsys=cygwin
+   ;;
++  
++  ## Cygwin ports
++  *-*-msys )
++    opsys=cygwin
++  ;;
+ 
+   ## HP 9000 series 700 and 800, running HP/UX
+   hppa*-hp-hpux10.2* )

--- a/emacs/Makefile.in.diff
+++ b/emacs/Makefile.in.diff
@@ -1,0 +1,11 @@
+--- admin/unidata/Makefile.in.orig	2014-11-08 01:37:29.445161700 +0100
++++ admin/unidata/Makefile.in	2014-11-08 01:33:48.642212600 +0100
+@@ -33,7 +33,7 @@
+ 
+ .PHONY: all compile install
+ 
+-all: ${top_srcdir}/src/macuvs.h ${DSTDIR}/charprop.el
++all: ${DSTDIR}/charprop.el
+ 
+ ${top_srcdir}/src/macuvs.h: ${srcdir}/uvs.el ${srcdir}/IVD_Sequences.txt
+ 	${EMACS} -batch -l "${srcdir}/uvs.el" \

--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -1,0 +1,77 @@
+# Maintainer: Ricky <rickleaf.wu@gmail.com>
+
+_realname="emacs"
+pkgname="emacs"
+pkgver=24.5
+pkgrel=1
+pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
+url="http://www.gnu.org/software/${_realname}/"
+license=('GPL3')
+arch=('any')
+depends=('ncurses')
+groups=('editors')
+makedepends=('gawk' 'perl' 'python2' 'python3' 'ruby' 'libiconv' 'ncurses-devel' 'libcrypt-devel')
+options=('strip')
+source=("http://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
+        'image.c.diff'
+        'lread.c.diff'
+        'Makefile.in.diff'
+        'configure.ac.diff'
+        'profiler.c.diff')
+sha256sums=('SKIP'
+            '4571d45ec26fd556e73a70bb0ab0a2a8fa1efc5e3b3c5b472ab68bb7dc9bf52c'
+            'b9db1b7d939301d0fedf52db6ac055f7265ee5bc0c3c757e394700ca39577b7f')
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch --binary --forward -p0 < "${srcdir}/image.c.diff"
+  patch --binary --forward -p0 < "${srcdir}/lread.c.diff"
+  patch --binary --forward -p0 < "${srcdir}/configure.ac.diff"
+  patch --binary --forward -p0 < "${srcdir}/Makefile.in.diff"
+  cd src
+  patch --binary --forward -p0 < "${srcdir}/profiler.c.diff"
+  cd ..
+  ./autogen.sh
+}
+
+build() {
+	
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  CPPFLAGS="-DNDEBUG"
+  CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
+  LDFLAGS="-s -Wl,-s"
+  ./configure \
+    --prefix=/usr \
+    --build="${CHOST}" \
+    --with-wide-int="yes" \
+    --with-w32="yes" \
+    --with-sound="yes" \
+    --with-file-notification="yes" \
+    --without-gpm \
+    --without-gconf \
+    --without-gsettings \
+    --without-selinux
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  make DESTDIR="${pkgdir}" install
+  rm -f "${pkgdir}/usr/bin/ctags.exe"
+  rm -f "${pkgdir}/usr/share/man/man1/ctags.1.gz"
+  rm -f "${pkgdir}/usr/share/info/info.info.gz"
+
+  local dir="${pkgdir}/usr/share/${_realname}"
+        dir="${dir}/$(ls -1 ${dir} | grep -E '([0-9]+\.[0-9]+)(\.[0-9]+)?')/src"
+
+  mkdir -p "${dir}"
+  cd "${srcdir}/${_realname}-${pkgver}/src"
+  cp *.c *.h *.m "${dir}"
+  
+}
+
+# TODO:
+# Patch `shell-file-name' default in the C source code similarly to
+# `source-directory'.

--- a/emacs/configure.ac.diff
+++ b/emacs/configure.ac.diff
@@ -1,0 +1,14 @@
+--- configure.ac	2015-04-02 15:23:06.000000000 +0800
++++ configure.ac.ricky	2015-11-20 14:46:09.179634100 +0800
+@@ -532,6 +532,11 @@ case "${canonical}" in
+   *-*-cygwin )
+     opsys=cygwin
+   ;;
++  
++  ## MSYS2 ports
++  *-*-msys )
++    opsys=cygwin
++  ;;
+ 
+   ## HP 9000 series 700 and 800, running HP/UX
+   hppa*-hp-hpux10.2* )

--- a/emacs/image.c.diff
+++ b/emacs/image.c.diff
@@ -1,0 +1,11 @@
+--- src/image.c.orig	2014-10-15 14:18:29.088716000 +0200
++++ src/image.c	2014-10-15 15:54:12.407522800 +0200
+@@ -7862,7 +7862,7 @@
+   };
+ 
+ #if defined HAVE_NTGUI && defined WINDOWSNT
+-static bool init_imagemagick_functions (void);
++#define init_imagemagick_functions NULL
+ #else
+ #define init_imagemagick_functions NULL
+ #endif

--- a/emacs/lread.c.diff
+++ b/emacs/lread.c.diff
@@ -1,0 +1,15 @@
+--- src/lread.c.orig	2014-11-04 20:29:22.129549000 +0100
++++ src/lread.c	2014-11-04 22:33:07.346414100 +0100
+@@ -4351,6 +4351,12 @@
+             } /* Vinstallation_directory != Vsource_directory */
+ 
+         } /* if Vinstallation_directory */
++      else
++        {
++          Vsource_directory
++            = Fexpand_file_name (build_string ("../"),
++                                 Fcar (decode_env_path (0, PATH_DATA, 0)));
++        }
+     }
+   else                          /* !initialized */
+     {

--- a/emacs/profiler.c.diff
+++ b/emacs/profiler.c.diff
@@ -1,0 +1,15 @@
+--- profiler.c	2015-04-02 15:23:06.000000000 +0800
++++ profiler_ricky.c	2015-11-21 08:49:42.605795300 +0800
+@@ -218,6 +218,12 @@ static EMACS_INT current_sampling_interv
+ 
+ /* Signal handler for sampling profiler.  */
+ 
++/* timer_getoverrun is not implemented on Cygwin, but the following
++   seems to be good enough for profiling. */
++#ifdef CYGWIN
++#define timer_getoverrun(x) 0
++#endif
++
+ static void
+ handle_profiler_signal (int signal)
+ {


### PR DESCRIPTION
I'd like to use posix standard GNU tools for WIN32 development.
I make emacs and emacs-git package for MSYS2.
Since we have not use X in MSYS2, we use win32 native UI and posix interface like Cygwin.
we can use emacs -nw and emacs with win32 GUI in mintty.