### PR TITLE
updated git-flow package to use stable master branch (version 1.9.1 now)

### DIFF
--- a/git-flow/PKGBUILD
+++ b/git-flow/PKGBUILD
@@ -2,14 +2,14 @@
 
 _realname=git-flow
 pkgname="${_realname}"
-pkgver=1.8.0.61.g2b013fc
+pkgver=1.9.1
 pkgrel=1
 pkgdesc="Git extensions to provide high-level repository operations for Vincent Driessen's branching model (AVH edition)"
 arch=('i686' 'x86_64')
 license=('BSD')
 depends=('git' 'util-linux')
 url="https://github.com/petervanderdoes/gitflow-avh"
-source=("${_realname}"::"git+https://github.com/petervanderdoes/gitflow-avh.git#branch=develop")
+source=("${_realname}"::"git+https://github.com/petervanderdoes/gitflow-avh.git#branch=master")
 sha1sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
rebuilded and tested git-flow locally with Git for Windows (2.6.3.1) SDK (1.0.1) with some feature and release branches.