### PR TITLE
Add a build script for w3m, a pager with WWW capabilities

### DIFF
--- a/w3m/0001-Accomodate-MSys2-s-libgc-API.patch
+++ b/w3m/0001-Accomodate-MSys2-s-libgc-API.patch
@@ -1,0 +1,29 @@
+From a9252d845480c6d2181c69271e2a1c2467d6d8f6 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Wed, 9 Dec 2015 18:34:13 +0000
+Subject: [PATCH] Accomodate MSys2's libgc API
+
+The libgc shipped with MSys2 declares the `GC_set_warn_proc()` function
+as returning void, so let's not use its return value.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/main.c b/main.c
+index b421943..e318cbc 100644
+--- a/main.c
++++ b/main.c
+@@ -833,7 +833,7 @@ main(int argc, char **argv, char **envp)
+     mySignal(SIGPIPE, SigPipe);
+ #endif
+ 
+-    orig_GC_warn_proc = GC_set_warn_proc(wrap_GC_warn_proc);
++    /* orig_GC_warn_proc = */ GC_set_warn_proc(wrap_GC_warn_proc);
+     err_msg = Strnew();
+     if (load_argc == 0) {
+ 	/* no URL specified */
+-- 
+2.6.2
+

--- a/w3m/0002-MSys-Make-sure-that-setmode-is-declared.patch
+++ b/w3m/0002-MSys-Make-sure-that-setmode-is-declared.patch
@@ -1,0 +1,31 @@
+From e61ab761ab3858cd20e8350ed4384cede4b570e8 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Thu, 10 Dec 2015 11:04:35 +0100
+Subject: [PATCH] MSys: Make sure that setmode() is declared
+
+In MSys2's context, `_setmode()` is declared, and `setmode()` will be
+defined for legacy only when including io.h. So let's do that.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ main.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/main.c b/main.c
+index e318cbc..c3bd958 100644
+--- a/main.c
++++ b/main.c
+@@ -31,6 +31,10 @@ extern int do_getch();
+ #endif				/* defined(USE_GPM) || defined(USE_SYSMOUSE) */
+ #endif
+ 
++#ifdef __MSYS__
++#include <io.h>
++#endif
++
+ #ifdef __MINGW32_VERSION
+ #include <winsock.h>
+ 
+-- 
+2.6.3
+

--- a/w3m/PKGBUILD
+++ b/w3m/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+pkgname=w3m
+_basever=0.5.3
+pkgver=${_basever}
+pkgrel=1
+pkgdesc="w3m is a pager with WWW capability"
+arch=('i686' 'x86_64')
+url="http://w3m.sourceforge.net/"
+license=('BSD')
+depends=('libgc' 'libiconv' 'libintl' 'openssl' 'zlib' 'ncurses')
+makedepends=('libgc-devel' 'libiconv-devel' 'gettext-devel' 'openssl-devel' 'zlib-devel' 'libtool' 'ncurses-devel')
+source=("http://downloads.sourceforge.net/${pkgname}/${pkgname}-${pkgver}.tar.gz"
+  '0001-Accomodate-MSys2-s-libgc-API.patch'
+  '0002-MSys-Make-sure-that-setmode-is-declared.patch')
+md5sums=('1b845a983a50b8dec0169ac48479eacc'
+  'bbcb377e3027726fed88e8b489d9f538'
+  '847a8d5d4d568116da7fcf22ad256409')
+
+prepare() {
+  cd ${srcdir}/${pkgname}-${_basever}
+
+  cp /usr/share/libtool/build-aux/config.{guess,sub} ./
+  patch -p1 <${srcdir}/0001-Accomodate-MSys2-s-libgc-API.patch
+  patch -p1 <${srcdir}/0002-MSys-Make-sure-that-setmode-is-declared.patch
+
+  ./configure
+}
+
+build() {
+  cd ${srcdir}/${pkgname}-${_basever}
+
+  make
+}
+
+package() {
+  cd ${srcdir}/${pkgname}-${_basever}
+
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
The w3m tool is particularly useful when rendering HTML pages into plain
text, as Git for Windows needs to do with its release notes.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>