### PR TITLE
Upgrade OpenSSH to version 7.1p2

### DIFF
--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=openssh
-pkgver=7.1p1
+pkgver=7.1p2
 pkgrel=1
 pkgdesc='Free version of the SSH connectivity tools'
 url='http://www.openssh.org/portable.html'
@@ -13,7 +13,7 @@ makedepends=('heimdal-devel' 'libedit-devel' 'libcrypt-devel' 'openssl-devel')
 source=("ftp://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkgname}-${pkgver}.tar.gz"
         openssh-6.3p1-fix-man-install.patch
         openssh-6.3p1-msys2.patch)
-sha1sums=('ed22af19f962262c493fcc6ed8c8826b2761d9b6'
+sha1sums=('9202f5a2a50c8a55ecfb830609df1e1fde97f758'
           '3caaf19c16dd13276f96353014826bd40a887a2e'
           'cb7ba3141fc0f3b2c1fa7c8cf510cb8a2c9fee00')
 


### PR DESCRIPTION
That version fixes CVE-2016-0777, a vulnerability that can be exploited
via a compromised SSH server. For details, see

	http://www.openssh.com/txt/release-7.1p2

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>