### PR TITLE
cyrus-sasl: Remove annoying debug message

### DIFF
--- a/cyrus-sasl/09-digest-md5-Remove-annoying-debug-message.patch
+++ b/cyrus-sasl/09-digest-md5-Remove-annoying-debug-message.patch
@@ -1,0 +1,37 @@
+From 37494bedb64dda4fb6621aa8a75e012d78ef4488 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=EB=A7=88=EB=88=84=EC=97=98?= <nalla@hamal.uberspace.de>
+Date: Wed, 20 Jan 2016 07:22:10 +0100
+Subject: [PATCH] digest-md5: Remove annoying debug message
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Every time an svn call is made, the message "DIGEST MD5 common mech free"
+appears in the application event log viewer. Other communities (See
+https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1372451.html)
+are supressing the message with a logcheck snippet. Since we do not have
+such a luxury in the msys2 environment, lets just remove the debug message
+for good.
+
+Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>
+---
+ plugins/digestmd5.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/plugins/digestmd5.c b/plugins/digestmd5.c
+index 4ab90dd..52ac085 100644
+--- a/plugins/digestmd5.c
++++ b/plugins/digestmd5.c
+@@ -1652,9 +1652,6 @@ static void digestmd5_common_mech_free(void *glob_context,
+ 	(digest_glob_context_t *) glob_context;
+     reauth_cache_t *reauth_cache = my_glob_context->reauth;
+     size_t n;
+-
+-    utils->log(utils->conn, SASL_LOG_DEBUG,
+-	       "DIGEST-MD5 common mech free");
+  
+     /* Prevent anybody else from freeing this as well */
+     my_glob_context->reauth = NULL;
+-- 
+2.7.0
+

--- a/cyrus-sasl/PKGBUILD
+++ b/cyrus-sasl/PKGBUILD
@@ -20,6 +20,7 @@ source=(#http://ftp.cyrusimap.org/cyrus-sasl/cyrus-sasl-${pkgver}.tar.gz
         06-fix-sqlite-search.patch
         07-fix-pkgconfig.patch
         08-cyrus-sasl-2.1.26-size_t.patch
+        09-digest-md5-Remove-annoying-debug-message.patch
         cyrus-sasl-2.1.26-msys2.patch)
 md5sums=('a7f4e5e559a0e37b3ffc438c9456e425'
          '7f52862a74ada70ed2e257990f9b4334'
@@ -30,6 +31,7 @@ md5sums=('a7f4e5e559a0e37b3ffc438c9456e425'
          '5b2af6369c98a778b82b53dee65789ca'
          '716c142e9779dd087ce231345adec0c2'
          'bcaafcbc79054e8356217213d6eda16d'
+         '26d2917065db8e3aca689feb4d78559b'
          '8a535fc4c12181c231192ef647a4ae9e')
 
 prepare() {
@@ -43,6 +45,7 @@ prepare() {
   patch -p1 -i ${srcdir}/06-fix-sqlite-search.patch
   patch -p2 -i ${srcdir}/07-fix-pkgconfig.patch
   patch -p1 -i ${srcdir}/08-cyrus-sasl-2.1.26-size_t.patch
+  patch -p1 -i ${srcdir}/09-digest-md5-Remove-annoying-debug-message.patch
   patch -p1 -i ${srcdir}/cyrus-sasl-2.1.26-msys2.patch
 
   sed 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/' -i configure.in


### PR DESCRIPTION
Every time an svn call is made, the message "DIGEST MD5 common mech free"
appears in the application event log viewer. Other communities (See
https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1372451.html)
are supressing the message with a logcheck snippet. Since we do not have
such a luxury in the msys2 environment, lets just remove the debug message
for good.

This fixes https://github.com/git-for-windows/git/issues/616

Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>