### PR TITLE
Add drone build script.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,14 @@
+build:
+  image: fracting/msys32
+  shell: msys32
+  commands:
+    - drone/build.sh
+
+notify:
+  irc:
+    prefix: build
+    nick: MSYS2-packages
+    channel: msys2
+    server:
+      host: irc.oftc.net
+      port: 6667

--- a/drone/build.sh
+++ b/drone/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# fetch first changed file, assume at most one package touched per commit
+TOUCHED=`git show --pretty="format:" --name-only | grep . | head -1`
+PKGDIR=`dirname $TOUCHED`
+if [ "$PKGDIR" = "." ]
+then
+    echo Nothing to test
+else
+    pushd $PKGDIR > /dev/null
+    makepkg -f -s --noconfirm --skippgpcheck --noprogressbar
+    popd > /dev/null
+fi


### PR DESCRIPTION
Hi, I've setup a Wine based Drone CI server at wine-ci.org, and created build script for MSYS2-packages, could you accept this script and register your account at wine-ci.org, so I can have real data to test the Wine CI server?
