### PR TITLE
drone: Return error when build failed.

### DIFF
--- a/drone/build.sh
+++ b/drone/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # fetch first changed file, assume at most one package touched per commit
 TOUCHED=`git show --pretty="format:" --name-only | grep . | head -1`
 PKGDIR=`dirname $TOUCHED`


### PR DESCRIPTION
The CI script should return failure if the build was not success.

Bad example:
http://wine-ci.org/Alexpux/MSYS2-packages/1

Good example:
http://wine-ci.org/fracting/MSYS2-packages/6

The standard way to solve this problem is adding `set -e` to build.sh, it was my fault didn't set it at the first time.