### PR TITLE
Introduce matrix build in Drone CI. Fix makedepends of pacman.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,7 @@ build:
   image: fracting/msys32
   shell: msys32
   commands:
+    - export RUNTEST=$$runtest
     - drone/build.sh
 
 notify:
@@ -12,3 +13,8 @@ notify:
     server:
       host: irc.oftc.net
       port: 6667
+
+matrix:
+  runtest:
+    - false
+    - true # allow failures

--- a/drone/build.sh
+++ b/drone/build.sh
@@ -6,7 +6,7 @@ git config --global user.email "ci@msys2.org"
 git config --global user.name "MSYS2 Build Bot"
 
 # fetch first changed file, assume at most one package touched per commit
-TOUCHED=`git show --pretty="format:" --name-only | grep . | head -1`
+TOUCHED=`git show -m --pretty="format:" --name-only | grep . | head -1`
 PKGDIR=`dirname $TOUCHED`
 if [ "$PKGDIR" = "." ]
 then

--- a/drone/build.sh
+++ b/drone/build.sh
@@ -13,6 +13,11 @@ then
     echo Nothing to test
 else
     pushd $PKGDIR > /dev/null
-    makepkg -f -s --noconfirm --skippgpcheck --noprogressbar
+    if [ "$RUNTEST" = "true" ]
+    then
+        makepkg -f -s --noconfirm --skippgpcheck --noprogressbar || true
+    else
+        makepkg -f -s --noconfirm --skippgpcheck --noprogressbar --nocheck
+    fi
     popd > /dev/null
 fi

--- a/drone/build.sh
+++ b/drone/build.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+git config --global user.email "ci@msys2.org"
+git config --global user.name "MSYS2 Build Bot"
+
 # fetch first changed file, assume at most one package touched per commit
 TOUCHED=`git show --pretty="format:" --name-only | grep . | head -1`
 PKGDIR=`dirname $TOUCHED`

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -34,9 +34,11 @@ makedepends=('asciidoc'
              'libtool'
              'git'
              'gettext-devel'
+             'heimdal-devel'
              'libarchive-devel'
              'libcurl-devel'
-             'libgpgme-devel')
+             'libgpgme-devel'
+             'libsqlite-devel')
 provides=('pacman-contrib')
 conflicts=('pacman-contrib')
 replaces=('pacman-contrib')


### PR DESCRIPTION
In this pull request, I add matrix build to .drone.yml:

```
matrix:
  runtest:
    - false
    - true # allow failures
```

Drone CI will run two build for every commit, one without `make check`, the other with `make check` but ignore the test errors.

Example: http://wine-ci.org/fracting/MSYS2-packages/16

In a long term, I'll try to maintain a white list / black list, incrementally force `make check` for more and more packages, push more packages to pass their test suite (on both Windows and Wine).

(BTW, wine-ci.org is slow, with only one vCPU, I'll upgrade it in a few days)
