### PR TITLE
AppVeyor continuous integration

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# AppVeyor Continuous Integration for MSYS2
+# Author: Renato Silva <br.renatosilva@gmail.com>
+
+# Functions
+success() { echo "Build success: ${@}"; exit 0; }
+failure() { echo "Build failure: ${@}"; exit 1; }
+
+# Prepare
+git config --global user.email 'ci@msys2.org'
+git config --global user.name 'MSYS2 AppVeyor CI'
+pacman --sync --noconfirm binutils || failure 'could not install binutils'
+
+# Recipes
+cd "$(dirname "$0")"
+files=($(git show -m --pretty=format: --name-only))
+for file in "${files[@]}"; do
+    [[ "${file}" = */PKGBUILD ]] && recipes+=("${file}")
+done
+test -n "${files}"   || failure 'could not detect changed files'
+test -z "${recipes}" && success 'no changes in package recipes'
+
+# Build
+for recipe in "${recipes[@]}"; do
+    cd "$(dirname ${recipe})"
+    makepkg --syncdeps --noconfirm --skippgpcheck || failure "could not build ${recipe}"
+    cd - > /dev/null
+done

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,2 @@
+build_script:
+    - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/appveyor.sh"


### PR DESCRIPTION
This adds AppVeyor CI for MSYS2 packages. When commits update package recipes, `makepkg` will be automatically executed for building the new package versions. Alexey, once you create your account in AppVeyor, simply pushing new commits should trigger the automated builds.

Since multiple packages can be touched and built per commit and some packages may take more than one hour for building, it is also interesting to ask AppVeyor for increasing the time limit to a few hours or something. I think they will be receptive about this.