### PR TITLE
switch to sha256 for some more packages

### DIFF
--- a/delta/PKGBUILD
+++ b/delta/PKGBUILD
@@ -13,8 +13,8 @@ depends=('perl')
 makedepends=('make' 'gcc' 'flex')
 source=("http://www.tigris.org/files/documents/3103/33566/delta-${dapkgver}.tar.gz"
         "0001-Cygwin-MSYS2-WIN32-Reopen-stdin-in-text-mode.patch")
-md5sums=('7be4ac4ae9c1eb01ccf29d413d4cc64a'
-         '03488670b3b7835bc1e2f4325f8d158e')
+sha256sums=('38184847a92b01b099bf927dbe66ef88fcfbe7d346a7304eeaad0977cb809ca0'
+            'af6302fd7fcc2d277b678b6aae78330635ce08939bb9dbcf1d75f0d93a1f8460')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${dapkgver}/"

--- a/diffstat/PKGBUILD
+++ b/diffstat/PKGBUILD
@@ -10,9 +10,9 @@ depends=('msys2-runtime')
 groups=('base-devel')
 license=('MIT')
 source=("ftp://invisible-island.net/${pkgname}/${pkgname}-${pkgver}.tgz"
-    diffstat-1.58-msys2.patch)
-md5sums=('6d6e13f7dcfe4db5da65c5175260ea47'
-         'a3378b96b375f922c76829dc2b58202f')
+        diffstat-1.58-msys2.patch)
+sha256sums=('fad5135199c3b9aea132c5d45874248f4ce0ff35f61abb8d03c3b90258713793'
+            'c4ec808391eea37809ba1f3eb043f01d52b486798db713cd6aef34d9f2a29162')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/gc/PKGBUILD
+++ b/gc/PKGBUILD
@@ -7,16 +7,16 @@ pkgrel=1
 pkgdesc="A garbage collector for C and C++"
 arch=('i686' 'x86_64')
 gropus=('libraries')
-url="http://www.hpl.hp.com/personal/Hans_Boehm/gc/"
+url="http://www.hboehm.info/gc/"
 license=('GPL')
-source=("http://www.hpl.hp.com/personal/Hans_Boehm/gc/gc_source/${pkgbase}-7.2d.tar.gz"
-    gc-7.2-msys2.patch
-    gc-7.2d-patch64.diff)
+source=("http://www.hboehm.info/gc/gc_source/${pkgbase}-7.2d.tar.gz"
+        gc-7.2-msys2.patch
+        gc-7.2d-patch64.diff)
 depends=('gcc-libs')
 options=('!libtool')
-md5sums=('91340b28c61753a789eb6077675d87d2'
-         '863ef4700d7f92262f3b282a44316654'
-         'db2dd5909ea0701aa6de2b8153c0b4a4')
+sha256sums=('d9fe0ae8650d43746a48bfb394cab01a319f3809cee19f8ebd16aa985b511c5e'
+            '49c92400fa79930b04ce50e1f0666c4b3c1397664a38af01eef537e840dffcb6'
+            '308d13996fd9aaba04b63278e63fc0dc9d81150276445657232cd731b5bbbf25')
 
 prepare() {
   cd "${srcdir}/${pkgbase}-7.2"

--- a/irssi/PKGBUILD
+++ b/irssi/PKGBUILD
@@ -7,16 +7,16 @@ pkgver=0.8.17
 pkgrel=0
 pkgdesc="Modular text mode IRC client with Perl scripting"
 arch=('i686' 'x86_64')
-url="http://irssi.org/"
+url="https://irssi.org/"
 license=('GPL')
 depends=('glib2-devel' 'openssl' 'libcrypt-devel' 'pcre-devel')
 optdepends=('perl-libwww: for the scriptassist script')
 backup=('etc/irssi.conf')
-source=("http://irssi.org/files/${pkgname}-${pkgver}.tar.bz2"
+source=("https://github.com/irssi-import/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.bz2"
         "0000_msysize.patch")
 options=('!strip')
-md5sums=('ecf64be47978d89a742b435a81cb47db'
-         '0fcc84aa7fcda66e5f97966bd3897bde')
+sha256sums=('3c9600cad2edf58f1d012febc1a0ba844274df6e331c01a9e935467705166807'
+            '59dd34cbc6e2c0734bb8979910a0de5049d033684efa12a0f703bf278be24176')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/isl/PKGBUILD
+++ b/isl/PKGBUILD
@@ -13,15 +13,15 @@ license=('MIT')
 source=(http://isl.gforge.inria.fr/${pkgname}-$pkgver.tar.xz
         isl-0.12.1-msys2.patch
         isl-0.14.1-no-undefined.patch)
-md5sums=('94fcd11e0b1c79250ae341affb1845ea'
-         '21b336bbc1b9b7806b3d927ccb9a95d3'
-         '38c67a10e197acb83217be17075070f9')
+sha256sums=('8882c9e36549fc757efa267706a9af733bb8d7fe3905cbfde43e17a89eea4675'
+            'cd29dc28cc9905b15d18ca0de66752c0587cd06485115b9892ea53ec39c59d35'
+            '83655a7202f0a0dcce1782d4b365252bf1ad12a522b7ad82ab578ee5ec46433b')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/isl-0.12.1-msys2.patch
   patch -p1 -i ${srcdir}/isl-0.14.1-no-undefined.patch
-  
+
   autoreconf -fi
 }
 

--- a/man-db/PKGBUILD
+++ b/man-db/PKGBUILD
@@ -19,10 +19,10 @@ install=${pkgname}.install
 source=(http://download-mirror.savannah.gnu.org/releases/man-db/${pkgname}-${pkgver}.tar.xz{,.sig}
         convert-mans
         man-db-2.6.7.1-msysize.patch)
-md5sums=('1b400af5b03c7ac44769dbfdd28a86fc'
-         'SKIP'
-         '0bd4b663cba0bbe85c4f457f775030bc'
-         '1a32cc0e6a7993d5155667a07f0efc49')
+sha256sums=('153f4d3c33f5f9b0c8484bb39d9d271f6ae4aa1b3f5d6d515879692dba944f0b'
+            'SKIP'
+            '15c9452984c06335543d9692e25d7825063d39e4d7897a224a36bbbd5e0ffaa8'
+            'a34881dc86c6e60204a6cddb33a6c1e66c397ef86d31ca8155ffb6308526120c')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}

--- a/man/PKGBUILD
+++ b/man/PKGBUILD
@@ -12,12 +12,12 @@ groups=('base-devel')
 depends=('bzip2' 'coreutils' 'gawk' 'groff' 'gzip' 'less' 'libcatgets' 'xz')
 backup=('etc/man.conf')
 #install=${pkgname}.install
-source=(http://primates.ximian.com/~flucifredi/man/man-${_ver}.tar.gz{,.sig}
+source=(#http://primates.ximian.com/~flucifredi/man/man-${_ver}.tar.gz{,.sig}
+        https://fossies.org/linux/misc/old/man-1.6g.tar.gz
         'man-1.6g-2.src.patch')
 options=('!libtool' 'emptydirs')
-md5sums=('ba154d5796928b841c9c69f0ae376660'
-         'SKIP'
-         '7171549b20a106f2f69cd4d949c9f445')
+sha256sums=('ccdcb8c3f4e0080923d7e818f0e4a202db26c46415eaef361387c20995b8959f'
+            '1fddd70f756abfdfeb70f74f44c5243748f4f58ced2d240d10a24d230504b802')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${_ver}

--- a/perl-Exporter-Lite/PKGBUILD
+++ b/perl-Exporter-Lite/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Exporter-Lite
 pkgname=perl-${_realname}
-pkgver=0.06
+pkgver=0.08
 pkgrel=1
 pkgdesc="lightweight exporting of functions and variables"
 arch=('any')
@@ -11,7 +11,7 @@ groups=('perl-modules')
 depends=('perl')
 license=('GPL' 'PerlArtistic')
 source=("http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/${_realname}-${pkgver}.tar.gz")
-md5sums=('309d37c45180b3c7716caf3d2ebe1617')
+sha256sums=('c05b3909af4cb86f36495e94a599d23ebab42be7a18efd0d141fc1586309dac2')
 
 prepare() {
   cd "$srcdir/${_realname}-${pkgver}"

--- a/perl-File-Which/PKGBUILD
+++ b/perl-File-Which/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=File-Which
 pkgname=perl-${_realname}
-pkgver=1.18
+pkgver=1.19
 pkgrel=1
 pkgdesc="Portable implementation of which"
 arch=('any')
@@ -12,8 +12,8 @@ depends=('perl' 'perl-Test-Script>=1.05')
 license=('GPL' 'PerlArtistic')
 source=("http://www.cpan.org/authors/id/P/PL/PLICEASE/${_realname}-${pkgver}.tar.gz"
         'File-Which-1.09.patch')
-md5sums=('554bfb36568d828fbeee64f4b9a9faa8'
-         '24762366105449a2b808ebcb105ca1db')
+sha256sums=('4bad2708c7efa1e756a94c285a64eebbedf9335d2da1b7d3bbed6409c86e9656'
+            '1e5b9187b5af3589e298e486c9b53b0b3ec61dd058173aab168e551163be0e5e')
 
 prepare() {
   cd "$srcdir/${_realname}-${pkgver}"

--- a/tig/PKGBUILD
+++ b/tig/PKGBUILD
@@ -10,7 +10,7 @@ url='http://jonas.nitro.dk/tig/'
 license=('GPL')
 arch=('i686' 'x86_64')
 source=("http://jonas.nitro.dk/${pkgname}/releases/${pkgname}-${pkgver}.tar.gz")
-md5sums=('d6eb13d31319d57a3f726d8238f8ebc0')
+sha256sums=('50c5179fd564b829b6b2cec087e66f10cf8799601de19350df0772ae77e4852f')
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"

--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -8,8 +8,8 @@ arch=('i686' 'x86_64')
 url='http://www.zsh.org/'
 license=('custom')
 makedepends=('ncurses-devel' 'pcre-devel' 'libiconv-devel' 'libgdbm-devel')
-source=("http://www.zsh.org/pub/zsh-${pkgver}.tar.gz"
-        "http://www.zsh.org/pub/zsh-${pkgver}-doc.tar.gz"
+source=("https://downloads.sourceforge.net/project/zsh/zsh/${pkgver}/zsh-${pkgver}.tar.gz"
+        "https://downloads.sourceforge.net/project/zsh/zsh-doc/${pkgver}/zsh-${pkgver}-doc.tar.gz"
         'config.guess::http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
         'config.sub::http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
         'zprofile'
@@ -18,16 +18,16 @@ source=("http://www.zsh.org/pub/zsh-${pkgver}.tar.gz"
         msysize.patch
         zsh-5.0.6-1.patch
         msys-symlink-hack.patch)
-md5sums=('8ba28a9ef82e40c3a271602f18343b2f'
-         '6f961a67b21f15cfbd735639af25cab5'
-         '08478727a5b38779bc62b632166b9f7f'
-         'b4b24b88055910a6b4dbb0f436af648e'
-         '24a9335edf77252a7b5f52e079f7aef7'
-         'ca9d481e1aa03e864734734d2267afb0'
-         '51a8f2979ce99db238bc38c2f477df74'
-         'edcafce2abb584422877327a9ca7b9de'
-         '2b3f986cccd301534909b399557973a5'
-         '79419542f6c2c33cb1a1e209fcd7e98c')
+sha256sums=('94ed5b412023761bc8d2f03c173f13d625e06e5d6f0dff2c7a6e140c3fa55087'
+            '05b8571012caa7aad64176ad378a7f159da8c48f11271e6a340a4c364f6e295d'
+            '99b9d011b738629e22b4ddbb73a2dda97b932077125e226bde0ce8138cf56c69'
+            '5ff3361df8a7b484ea0fc154a89deb69e1365066cba9219b59294c6ac1e3a1d2'
+            '230832038c3b8f67fdb1b284ac5f68d709cdb7f1bc752b0e60657b9b9d091045'
+            '95fbe7af62b22143911bbe691a79381bf00a35c7818a5418f6ee9eade1e4a690'
+            'b3f74a10a27eff498124adc96bc8c5cced7bb15e18c2603d7c3490a81e3c2e48'
+            '4c13a4b3685b04747c48e2d3c983ec1bf01094967e39c9cabef8c9029da6e6bf'
+            '336a8e6e93b778e7aec27348619b7200e0a75e5cf14dce720afd9dd6f836ea2c'
+            'de515b0d86c13c29a663b4ba0fdb338dea83f82f145cf8c4da78d30369f963e4')
 
 prepare() {
     cd ${srcdir}/${pkgname}-${pkgver}


### PR DESCRIPTION
Only these two remained MD5, both broken: `cygrunsrv`, `libevent`
