### PR TITLE
added patch to enable Windows SSPI authentication for msys

### DIFF
--- a/serf/07-sspi-auth.patch
+++ b/serf/07-sspi-auth.patch
@@ -1,0 +1,39 @@
+--- origsrc/serf-1.3.2//SConstruct
++++ src/serf-1.3.2//SConstruct
+@@ -367,8 +367,11 @@ if gssapi and CALLOUT_OKAY:
+         return env.MergeFlags(cmd, unique)
+     env.ParseConfig('$GSSAPI --libs gssapi', parse_libs)
+     env.Append(CPPDEFINES='SERF_HAVE_GSSAPI')
+-if sys.platform == 'win32':
++if sys.platform == 'win32' or sys.platform == 'msys':
+   env.Append(CPPDEFINES=['SERF_HAVE_SSPI'])
++  if sys.platform == 'msys':
++    env['SECUR32_LIBS'] = '-lsecur32'
++    env.Append(LIBS='secur32')
+
+ # On some systems, the -R values that APR describes never make it into actual
+ # RPATH flags. We'll manually map all directories in LIBPATH into new
+@@ -385,8 +388,9 @@ pkgconfig = env.Textfile('serf-%d.pc' % (MAJOR,),
+                            '@LIBDIR@': '$LIBDIR',
+                            '@INCLUDE_SUBDIR@': 'serf-%d' % (MAJOR,),
+                            '@VERSION@': '%d.%d.%d' % (MAJOR, MINOR, PATCH),
+-                           '@LIBS@': '%s %s %s -lz' % (apu_libs, apr_libs,
+-                                                       env.get('GSSAPI_LIBS', '')),
++                           '@LIBS@': '%s %s %s %s -lz' % (apu_libs, apr_libs,
++                                                       env.get('GSSAPI_LIBS', ''),
++                              env.get('SECUR32_LIBS', '')),
+                            })
+
+ env.Default(lib_static, lib_shared, pkgconfig)
+
+--- origsrc/serf-1.3.2/auth/auth_spnego_sspi.c
++++ src/serf-1.3.2/auth/auth_spnego_sspi.c
+@@ -22,6 +22,8 @@
+ #include <apr_strings.h>
+
+ #define SECURITY_WIN32
++#include <windows.h>
++#include <netdb.h>
+ #include <sspi.h>
+
+ /* SEC_E_MUTUAL_AUTH_FAILED is not defined in Windows Platform SDK 5.0. */

--- a/serf/PKGBUILD
+++ b/serf/PKGBUILD
@@ -3,22 +3,23 @@
 pkgbase=serf
 pkgname=("lib${pkgbase}" "lib${pkgbase}-devel")
 pkgver=1.3.8
-pkgrel=1
+pkgrel=2
 pkgdesc="High-performance asynchronous HTTP client library"
 arch=('i686' 'x86_64')
-url="http://code.google.com/p/serf/"
+url="https://serf.apache.org/"
 license=('Apache')
 makedepends=('scons' 'apr-util-devel' 'heimdal-devel' 'zlib-devel' 'openssl-devel' 'libiconv-devel')
-source=(http://serf.googlecode.com/svn/src_releases/${pkgbase}-${pkgver}.tar.bz2
+source=(#https://serf.googlecode.com/svn/src_releases/${pkgbase}-${pkgver}.tar.bz2
+        https://archive.apache.org/dist/serf/${pkgbase}-${pkgver}.tar.bz2
         03-destdir.patch
         05-disable-SHLIBVERSION.patch
         06-strcasecmp.patch
         07-sspi-auth.patch)
-md5sums=('2e4efe57ff28cb3202a112e90f0c2889'
-         'cb0cc5190fc77c349a8a3ccc0892bc37'
-         '4ef49148ee9e19bb718de41294b5643c'
-         '21cf6762552937c3128161b1397d0ff2'
-         'f0f81c38a0de6544040541b1e0829ec3')
+sha256sums=('e0500be065dbbce490449837bb2ab624e46d64fc0b090474d9acaa87c82b2590'
+            '96d910284bb71ed1baee1f2ec9d72e5e057d6b35c5b129e18be1e2324c8ab151'
+            '91c972e4bbe14940a90f1cafaf4eb6e4c0157d6daace04da2600b496e347767a'
+            'a17d414acc2a8d7e30b20b7892ec4b4c0a6fbc333aab7c0d85d42ce611f10bf8'
+            '5df99d246cbec12f840f11a46e4dbacc70d2e694dcf39c7431a5352105fd67fc')
 
 prepare() {
   cd ${pkgbase}-${pkgver}

--- a/serf/PKGBUILD
+++ b/serf/PKGBUILD
@@ -12,11 +12,13 @@ makedepends=('scons' 'apr-util-devel' 'heimdal-devel' 'zlib-devel' 'openssl-deve
 source=(http://serf.googlecode.com/svn/src_releases/${pkgbase}-${pkgver}.tar.bz2
         03-destdir.patch
         05-disable-SHLIBVERSION.patch
-        06-strcasecmp.patch)
+        06-strcasecmp.patch
+        07-sspi-auth.patch)
 md5sums=('2e4efe57ff28cb3202a112e90f0c2889'
          'cb0cc5190fc77c349a8a3ccc0892bc37'
          '4ef49148ee9e19bb718de41294b5643c'
-         '21cf6762552937c3128161b1397d0ff2')
+         '21cf6762552937c3128161b1397d0ff2'
+         'f0f81c38a0de6544040541b1e0829ec3')
 
 prepare() {
   cd ${pkgbase}-${pkgver}
@@ -24,6 +26,7 @@ prepare() {
   patch -p1 -i ${srcdir}/03-destdir.patch
   patch -p2 -i ${srcdir}/05-disable-SHLIBVERSION.patch
   patch -p2 -i ${srcdir}/06-strcasecmp.patch
+  patch -p2 -i ${srcdir}/07-sspi-auth.patch
 }
 
 build() {


### PR DESCRIPTION
This patch enables SSPI - the Windows integrated authentication to the serf library. As result serf is using the users Kerberos TGT from the MS LSA for authentication against a kerberised Subversion server.

@dscho created the patch  originally, have a look to the [conversation](https://github.com/git-for-windows/git/issues/550).