### PR TITLE
Drone CI: Always pull latest image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 build:
   image: fracting/msys32
+  pull: true
   shell: msys32
   commands:
     - export RUNTEST=$$runtest


### PR DESCRIPTION
Now our CI has multiple server as workers, as a result, same configuration running on different worker machines might have different environment especially docker image version. docker image tag "latest" doesn't really mean latest build from upstream, it is just a name. To force fetch latest build, we need to enable "pull: true" in .drone.yml.

This patch should fix failure in https://tea-ci.org/Alexpux/MINGW-packages/371 which was caused by outdated msys2-runtime with an upgrade without restart.

I'll send a similar patch to MINGW-packages repo.