### PR TITLE
Improvements for continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,25 @@
+environment:
+    DEPLOY_ACCOUNT: Alexpux
+    PACMAN_REPOSITORY_NAME: ci.msys
+    PACMAN_REPOSITORY_URL: https://dl.bintray.com/$(APPVEYOR_ACCOUNT_NAME)/msys2
+    BUILD_URL: https://ci.appveyor.com/project/$(APPVEYOR_ACCOUNT_NAME)/$(APPVEYOR_PROJECT_NAME)/build/$(APPVEYOR_BUILD_VERSION)
+
 build_script:
     # TODO: implement update-core --noconfirm and replace the below command line
     - C:\msys64\usr\bin\pacman --sync --refresh --refresh --needed --noconfirm msys2-runtime msys2-runtime-devel bash pacman pacman-mirrors
     - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
+
+artifacts:
+    - path: artifacts\*
+
+deploy:
+    - provider: BinTray
+      username: $(APPVEYOR_ACCOUNT_NAME)
+      subject: $(APPVEYOR_ACCOUNT_NAME)
+      package: $(PACMAN_REPOSITORY_NAME)
+      version: latest
+      publish: true
+      override: true
+      repo: msys2
+      api_key:
+          secure: BINTRAY_TOKEN_ENCRYPTED_BY_APPVEYOR

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -17,6 +17,7 @@ list_commits  || failure 'Could not detect added commits'
 list_packages || failure 'Could not detect changed files'
 message 'Processing changes' "${commits[@]}"
 test -z "${packages}" && success 'No changes in package recipes'
+define_build_order || failure 'Could not determine build order'
 
 # Build
 message 'Building packages' "${packages[@]}"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -4,20 +4,9 @@
 # Author: Renato Silva <br.renatosilva@gmail.com>
 # Author: Qian Hong <fracting@gmail.com>
 
-# Functions
-failure()       { colored; printf "\n${red}[MSYS2 CI] FAILURE:${normal} ${1}.\n\n"; exit 1; }
-success()       { colored; printf "\n${green}[MSYS2 CI] SUCCESS:${normal} ${1}.\n\n"; exit 0; }
-status()        { colored; printf "\n${cyan}[MSYS2 CI]${normal} ${1}\n\n"; printf "${2:+\t%s\n}" "${2:+${@:2}}"; }
-colored()       { [[ -t 1 && -z "${normal}" ]] || return; normal='\e[0m'; red='\e[1;31m'; green='\e[1;32m'; cyan='\e[1;36m'; }
-execute()       { cd "${package:-.}"; status "${package:+$package: }${1}"; ${@:2} || failure "${package:+$package: }${1} failed"; cd - > /dev/null; }
-git_config()    { test -n "$(git config ${1})" && return 0; git config --global "${1}" "${2}" || failure 'Could not configure Git for makepkg'; }
-as_list()       { local -n nameref="${1}"; local result=1; while IFS= read -r line; do test -z "${line}" && continue; result=0; [[ "${line}" = ${2} ]] && nameref+=("${line/${3}/}"); done <<<"${4}"; return ${result}; }
-list_changes()  { as_list "${@:1:3}" "$(git log "${@:4}" upstream/master.. | sort -u)" || as_list "${@:1:3}" "$(git log "${@:4}" HEAD^.. | sort -u)"; }
-list_packages() { list_changes packages '*/PKGBUILD' '%/PKGBUILD' --pretty=format: --name-only; }
-list_commits()  { list_changes commits '*' '#*::' --pretty=format:'%ai::[%h] %s'; }
-
 # Configure
 cd "$(dirname "$0")"
+source 'ci-library.sh'
 git_config user.email 'ci@msys2.org'
 git_config user.name  'MSYS2 Continuous Integration'
 git remote add upstream 'https://github.com/Alexpux/MSYS2-packages'
@@ -26,11 +15,11 @@ git fetch --quiet upstream
 # Detect
 list_commits  || failure 'Could not detect added commits'
 list_packages || failure 'Could not detect changed files'
-status 'Processing changes' "${commits[@]}"
+message 'Processing changes' "${commits[@]}"
 test -z "${packages}" && success 'No changes in package recipes'
 
 # Build
-status 'Building packages' "${packages[@]}"
+message 'Building packages' "${packages[@]}"
 execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade
 for package in "${packages[@]}"; do
     execute 'Building' makepkg --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -7,6 +7,7 @@
 # Configure
 cd "$(dirname "$0")"
 source 'ci-library.sh'
+deploy_enabled && mkdir artifacts
 git_config user.email 'ci@msys2.org'
 git_config user.name  'MSYS2 Continuous Integration'
 git remote add upstream 'https://github.com/Alexpux/MSYS2-packages'
@@ -23,7 +24,17 @@ define_build_order || failure 'Could not determine build order'
 message 'Building packages' "${packages[@]}"
 execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade
 for package in "${packages[@]}"; do
-    execute 'Building' makepkg --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
+    execute 'Building binary' makepkg --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
+    execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource
     yes|execute 'Installing' pacman --noprogressbar --upgrade *.pkg.tar.xz
+    deploy_enabled && mv "${package}"/*.pkg.tar.xz artifacts
+    deploy_enabled && mv "${package}"/*.src.tar.gz artifacts
+    unset package
 done
-success 'All packages built and installed successfully'
+
+# Deploy
+deploy_enabled && cd artifacts || success 'All packages built successfully'
+execute 'Generating pacman repository' create_pacman_repository "${PACMAN_REPOSITORY_NAME:-ci-build}" "${PACMAN_REPOSITORY_URL}"
+execute 'Generating build references'  create_build_references  "${PACMAN_REPOSITORY_NAME:-ci-build}" "${PACMAN_REPOSITORY_URL}"
+execute 'SHA-256 checksums' sha256sum *
+success 'All artifacts built successfully'

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Continuous Integration Library for MSYS2
+# Author: Renato Silva <br.renatosilva@gmail.com>
+# Author: Qian Hong <fracting@gmail.com>
+
+# Enable colors
+if [[ -t 1 ]]; then
+    normal='\e[0m'
+    red='\e[1;31m'
+    green='\e[1;32m'
+    cyan='\e[1;36m'
+fi
+
+# Basic status function
+_status() {
+    local type="${1}"
+    local status="${package:+${package}: }${2}"
+    local items=("${@:3}")
+    case "${type}" in
+        failure) local -n nameref_color='red';   title='[MSYS2 CI] FAILURE:' ;;
+        success) local -n nameref_color='green'; title='[MSYS2 CI] SUCCESS:' ;;
+        message) local -n nameref_color='cyan';  title='[MSYS2 CI]'
+    esac
+    printf "\n${nameref_color}${title}${normal} ${status}\n\n"
+    printf "${items:+\t%s\n}" "${items:+${items[@]}}"
+}
+
+# Convert lines to array
+_as_list() {
+    local -n nameref_list="${1}"
+    local filter="${2}"
+    local strip="${3}"
+    local lines="${4}"
+    local result=1
+    while IFS= read -r line; do
+        test -z "${line}" && continue
+        result=0
+        [[ "${line}" = ${filter} ]] && nameref_list+=("${line/${strip}/}")
+    done <<< "${lines}"
+    return "${result}"
+}
+
+# Changes since master or from head
+_list_changes() {
+    local list_name="${1}"
+    local filter="${2}"
+    local strip="${3}"
+    local git_options=("${@:4}")
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" upstream/master.. | sort -u)" ||
+    _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" HEAD^.. | sort -u)"
+}
+
+# Git configuration
+git_config() {
+    local name="${1}"
+    local value="${2}"
+    test -n "$(git config ${name})" && return 0
+    git config --global "${name}" "${value}" && return 0
+    failure 'Could not configure Git for makepkg'
+}
+
+# Run command with status
+execute(){
+    local status="${1}"
+    local command=("${@:2}")
+    cd "${package:-.}"
+    message "${status}"
+    ${command[@]} || failure "${status} failed"
+    cd - > /dev/null
+}
+
+# Added commits or changed recipes
+list_commits()  { _list_changes commits '*' '#*::' --pretty=format:'%ai::[%h] %s'; }
+list_packages() { _list_changes packages '*/PKGBUILD' '%/PKGBUILD' --pretty=format: --name-only; }
+
+# Status functions
+failure() { local status="${1}"; local items=("${@:2}"); _status failure "${status}." "${items[@]}"; exit 1; }
+success() { local status="${1}"; local items=("${@:2}"); _status success "${status}." "${items[@]}"; exit 0; }
+message() { local status="${1}"; local items=("${@:2}"); _status message "${status}"  "${items[@]}"; }

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -51,6 +51,46 @@ _list_changes() {
     _as_list "${list_name}" "${filter}" "${strip}" "$(git log "${git_options[@]}" HEAD^.. | sort -u)"
 }
 
+# Get package information
+_package_info() {
+    local package="${1}"
+    local properties=("${@:2}")
+    for property in "${properties[@]}"; do
+        local -n nameref_property="${property}"
+        nameref_property=($(
+            source "${package}/PKGBUILD"
+            declare -n nameref_property="${property}"
+            echo "${nameref_property[@]}"))
+    done
+}
+
+# Package provides another
+_package_provides() {
+    local package="${1}"
+    local another="${2}"
+    local pkgname provides
+    _package_info "${package}" pkgname provides
+    for pkg_name in "${pkgname[@]}";  do [[ "${pkg_name}" = "${another}" ]] && return 0; done
+    for provided in "${provides[@]}"; do [[ "${provided}" = "${another}" ]] && return 0; done
+    return 1
+}
+
+# Add package to build after required dependencies
+_build_add() {
+    local package="${1}"
+    local depends makedepends
+    for sorted_package in "${sorted_packages[@]}"; do
+        [[ "${sorted_package}" = "${package}" ]] && return 0
+    done
+    _package_info "${package}" depends makedepends
+    for dependency in "${depends[@]}" "${makedepends[@]}"; do
+        for unsorted_package in "${packages[@]}"; do
+            _package_provides "${unsorted_package}" "${dependency}" && _build_add "${unsorted_package}"
+        done
+    done
+    sorted_packages+=("${package}")
+}
+
 # Git configuration
 git_config() {
     local name="${1}"
@@ -68,6 +108,15 @@ execute(){
     message "${status}"
     ${command[@]} || failure "${status} failed"
     cd - > /dev/null
+}
+
+# Sort packages by dependency
+define_build_order() {
+    local sorted_packages=()
+    for unsorted_package in "${packages[@]}"; do
+        _build_add "${unsorted_package}"
+    done
+    packages=("${sorted_packages[@]}")
 }
 
 # Added commits or changed recipes


### PR DESCRIPTION
**Support for package deployment**

The CI system can now deploy built packages to remote repositories. AppVeyor has been configured to export packages to Bintray. Drone can be configured to perform similar export as well. Services other than Bintray can also be configured. Alexey, deployment should start working once you complete the following configuration:

 1. Create a Bintray account named the same as your AppVeyor account.
 2. Create the Bintray generic repository _msys2_.
 3. Create the Bintray packages _ci.mingw_ and _ci.msys_.
 4. Replace `BINTRAY_TOKEN_ENCRYPTED_BY_APPVEYOR` with the actual value.

The same procedure can be used for repository clones, with the additional step of replacing `DEPLOY_ACCOUNT` with your own GitHub username. Leaving this unchanged will keep deployment disabled. The exported packages should be installable with:

```bash
repman add ci.mingw 'https://dl.bintray.com/Alexpux/msys2'
repman add ci.msys  'https://dl.bintray.com/Alexpux/msys2'
pacman --sync ci.mingw/package
pacman --sync ci.msys/package
```

**Build packages by dependency order**

Changed dependencies are now built before the packages that require them. The actual package names are detected, as well as dependencies provided by alternative packages.

**Source refactoring for helper functions**

The helper functions have been moved to a separate library file with more readable code. The main script should now be more straightforward to read.