### PR TITLE
filesystem: handle ctrl+[right/left] for word forward/backward in mintty

### DIFF
--- a/filesystem/dot.inputrc
+++ b/filesystem/dot.inputrc
@@ -102,6 +102,8 @@ $if mode=emacs
     "\e[3~": delete-char      # Delete Key
     "\e\e[C": forward-word      # Alt-Right
     "\e\e[D": backward-word      # Alt-Left
+    "\e[1;5C": forward-word   # ctrl + right
+    "\e[1;5D": backward-word  # ctrl + left 
     "\e[17~": "Function Key 6"
     "\e[18~": "Function Key 7"
     "\e[19~": "Function Key 8"


### PR DESCRIPTION
fix for https://github.com/Alexpux/MSYS2-packages/issues/511