### PR TITLE
ruby: add patch

### DIFF
--- a/ruby/2.3.0-msys2-resolv.patch
+++ b/ruby/2.3.0-msys2-resolv.patch
@@ -1,0 +1,22 @@
+#fix for upstream bug #12071
+diff -ruN ruby-2.3.0.orig/lib/resolv.rb ruby-2.3.0/lib/resolv.rb
+--- ruby-2.3.0.orig/lib/resolv.rb	2016-03-30 18:19:22.528842900 +0200
++++ ruby-2.3.0/lib/resolv.rb	2016-03-30 18:21:53.232329900 +0200
+@@ -168,7 +168,7 @@
+ 
+   class Hosts
+     begin
+-      raise LoadError unless /mswin|mingw|cygwin|msys/ =~ RUBY_PLATFORM
++      raise LoadError unless /mswin|mingw/ =~ RUBY_PLATFORM
+       require 'win32/resolv'
+       DefaultFileName = Win32::Resolv.get_hosts_path
+     rescue LoadError
+@@ -967,7 +967,7 @@
+         if File.exist? filename
+           config_hash = Config.parse_resolv_conf(filename)
+         else
+-          if /mswin|cygwin|msys|mingw|bccwin/ =~ RUBY_PLATFORM
++          if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
+             require 'win32/resolv'
+             search, nameserver = Win32::Resolv.get_resolv_info
+             config_hash = {}

--- a/ruby/PKGBUILD
+++ b/ruby/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('ruby' 'ruby-docs')
 pkgver=2.3.0
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url='https://www.ruby-lang.org/en/'
 license=('BSD' 'custom')
@@ -15,7 +15,8 @@ source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/ruby-${pkgver//_/-}.t
         2.2.2-cygwin-compile.patch
         2.0.0-pkgconfig-version.patch
         'gemrc'
-        'ruby-2.3.0-msys2.patch')
+        'ruby-2.3.0-msys2.patch'
+	'2.3.0-msys2-resolv.patch')
 sha256sums=('ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e'
             '3453f6b8a77b3a3284b217264769287c29e00e5c3b0e535aeee6a17a4d898258'
             'd8a54a6c57d31411916ae115a798023115dcbca63faf8f3b5ccd91f4bdbd1215'
@@ -23,7 +24,8 @@ sha256sums=('ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e'
             '5fffe4fa469721bfe271650dae142c5a0274c22705e4be01541371d74a5de23d'
             'd74c014e3b5ff848df86c071e8562e699c4488f156c22d3a76d87fab8b9c95d8'
             '4bb7eb2fe66e396ed16b589cdb656831407b39ad4e138d88536754c0448ac614'
-            'e8acdc2de2a267b130f10c423e41fb3e9d4902a4e77eadaa655257b23a47a805')
+            'e8acdc2de2a267b130f10c423e41fb3e9d4902a4e77eadaa655257b23a47a805'
+			'f5921684e9bd82283cd359cf7be5f31f7020303cee565a23d2dadb4f36cf2dcd')
 
 prepare() {
   cd ${srcdir}/ruby-${pkgver//_/-}
@@ -33,6 +35,7 @@ prepare() {
   patch -p2 -i ${srcdir}/2.2.2-cygwin-compile.patch
   patch -p2 -i ${srcdir}/2.0.0-pkgconfig-version.patch
   patch -p1 -i ${srcdir}/ruby-2.3.0-msys2.patch
+  patch -p1 -i ${srcdir}/2.3.0-msys2-resolv.patch
   autoreconf -fi
 }
 


### PR DESCRIPTION
Hopefully fixes #515

$ gem install bundler
Fetching: bundler-1.11.2.gem (100%)
WARNING:  You don't have /home/mati865/.gem/ruby/2.3.0/bin in your PATH,
          gem executables will not run.
Successfully installed bundler-1.11.2
Parsing documentation for bundler-1.11.2
Installing ri documentation for bundler-1.11.2
Done installing documentation for bundler after 20 seconds
1 gem installed

Other commands not tested
