### PR TITLE
.bat-files: exit only from .bat file instead of terminating parent command processor

### DIFF
--- a/filesystem/mingw32_shell.bat
+++ b/filesystem/mingw32_shell.bat
@@ -43,15 +43,15 @@ if "x%MSYSCON%" == "xconsole.exe" goto startconsolez
 :startmintty
 if NOT EXIST %WD%mintty.exe goto startsh
 start %WD%mintty -i /msys2.ico /usr/bin/bash --login %*
-exit
+exit /b %ERRORLEVEL%
 
 :startconsolez
 cd %WD%..\lib\ConsoleZ
 start console -t "MinGW" -r "%*"
-exit
+exit /b %ERRORLEVEL%
 
 :startsh
 start %WD%sh --login -i %*
-exit
+exit /b %ERRORLEVEL%
 
 :EOF

--- a/filesystem/mingw64_shell.bat
+++ b/filesystem/mingw64_shell.bat
@@ -43,15 +43,15 @@ if "x%MSYSCON%" == "xconsole.exe" goto startconsolez
 :startmintty
 if NOT EXIST %WD%mintty.exe goto startsh
 start %WD%mintty -i /msys2.ico /usr/bin/bash --login %*
-exit
+exit /b %ERRORLEVEL%
 
 :startconsolez
 cd %WD%..\lib\ConsoleZ
 start console -t "MinGW" -r "%*"
-exit
+exit /b %ERRORLEVEL%
 
 :startsh
 start %WD%sh --login -i %*
-exit
+exit /b %ERRORLEVEL%
 
 :EOF

--- a/filesystem/msys2_shell.bat
+++ b/filesystem/msys2_shell.bat
@@ -43,15 +43,15 @@ if "x%MSYSCON%" == "xconsole.exe" goto startconsolez
 :startmintty
 if NOT EXIST %WD%mintty.exe goto startsh
 start %WD%mintty -i /msys2.ico /usr/bin/bash --login %*
-exit
+exit /b %ERRORLEVEL%
 
 :startconsolez
 cd %WD%..\lib\ConsoleZ
 start console -t "MSys2" -r "%*"
-exit
+exit /b %ERRORLEVEL%
 
 :startsh
 start %WD%sh --login -i %*
-exit
+exit /b %ERRORLEVEL%
 
 :EOF


### PR DESCRIPTION
bypass result of "start" to calling process.


Currently if Msys is started from another .bat file by `call path/mingw64_shell.bat`, those .bat file is terminated at this command. To exit only from .bat file instead of terminating cmd.exe, `exit /b` must be used.