### PR TITLE
.bat-files: added support for ConEmu terminal emulation

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=filesystem
 pkgver=2016.04
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -52,7 +52,7 @@ sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
             'b896abbbd7187184045e42e2646d4cb25f5484a27558f780137c7ec9ca9bdc47'
             '50c3746d621e682e3560e1b37cc1ac5d988460064a20ed15f107c203ac5ad622'
             '9620bdf1c82ea3f14c3553c44a2006ea61ff3f5a775a2a053130a59cc186daf5'
-            '15e6605867d891c0cc64ed3506280bc9d391d52475471a39cd809e6de289d91d'
+            'a134700d6e20ef47bfbb1d430abb4b9f79c45376c67e5689f37af0dd1c8c6aa5'
             '147773db7cb87fe09f735b5f47ff0dc3e1ffb8bf3149a51636341f7f61feec11'
             'fd6d475058e122823aa8665d8c8bf6bde251524fbba954c1f1c941c10ea46f7f'
             'eae2795591117fd3d7665d94a7b1827e13176580bc5a16d65350c584df5aaa7e'


### PR DESCRIPTION
ConEmu used only if requested by `-conemu` parameter.