### PR TITLE
I believe the gcc dependency is not needed there

### DIFF
--- a/bc/PKGBUILD
+++ b/bc/PKGBUILD
@@ -7,8 +7,8 @@ pkgdesc="An arbitrary precision calculator language"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/bc"
 license=('GPL')
-depends=('gcc' 'libreadline' 'ncurses')
-builddepends=('libreadline-devel' 'ncurses-devel')
+depends=('libreadline' 'ncurses')
+builddepends=('gcc' 'libreadline-devel' 'ncurses-devel')
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz
         0001-Fix-readline-prototype.patch)
 sha256sums=('4ef6d9f17c3c0d92d8798e35666175ecd3d8efac4009d6457b5c99cea72c0e33'


### PR DESCRIPTION
moved gcc to builddepends