### PR TITLE
jsoncpp install pkgdir

### DIFF
--- a/jsoncpp/PKGBUILD
+++ b/jsoncpp/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname="jsoncpp"
 pkgver=1.7.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library for interacting with JSON"
 arch=('any')
 url="https://github.com/open-source-parsers/jsoncpp"

--- a/jsoncpp/PKGBUILD
+++ b/jsoncpp/PKGBUILD
@@ -25,6 +25,8 @@ build() {
 
   cmake \
     -DCMAKE_INSTALL_PREFIX:PATH="${pkgdir}" \
+    -DINCLUDE_INSTALL_DIR:PATH="${pkgdir}/include" \
+    -DLIBRARY_INSTALL_DIR:PATH="${pkgdir}/lib" \
     -DCMAKE_BUILD_TYPE=Release \
     -DJSONCPP_WITH_CMAKE_PACKAGE=ON \
     "${srcdir}/${pkgname}-$pkgver"


### PR DESCRIPTION
expecting install under "/usr"
no under the root "/"
#548 