### PR TITLE
ccache: add MSYS package

### DIFF
--- a/ccache/MSYS2-dont-use-symlinks.patch
+++ b/ccache/MSYS2-dont-use-symlinks.patch
@@ -1,0 +1,36 @@
+diff -urN ccache-3.2.4.orig/ccache.h ccache-3.2.4/ccache.h
+--- ccache-3.2.4.orig/ccache.h	2015-10-08 21:14:23.000000000 +0200
++++ ccache-3.2.4/ccache.h	2016-04-17 19:42:45.063373100 +0200
+@@ -248,8 +248,9 @@
+ #endif
+ 
+ /* mkstemp() on some versions of cygwin don't handle binary files, so
+-   override */
+-#ifdef __CYGWIN__
++   override,
++   however MSYS2 is fine */
++#if defined(__CYGWIN__) && !defined(__MSYS__)
+ #undef HAVE_MKSTEMP
+ #endif
+ 
+diff -urN ccache-3.2.4.orig/lockfile.c ccache-3.2.4/lockfile.c
+--- ccache-3.2.4.orig/lockfile.c	2015-10-08 21:14:23.000000000 +0200
++++ ccache-3.2.4/lockfile.c	2016-04-17 19:38:29.151513300 +0200
+@@ -36,7 +36,7 @@
+ 	char *my_content = NULL, *content = NULL, *initial_content = NULL;
+ 	const char *hostname = get_hostname();
+ 	bool acquired = false;
+-#ifdef _WIN32
++#if defined(_WIN32) || defined(__MSYS__)
+ 	const size_t bufsize = 1024;
+ 	int fd, len;
+ #else
+@@ -48,7 +48,7 @@
+ 		free(my_content);
+ 		my_content = format("%s:%d:%d", hostname, (int)getpid(), (int)time(NULL));
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) || defined(__MSYS__)
+ 		fd = open(lockfile, O_WRONLY|O_CREAT|O_EXCL|O_BINARY, 0666);
+ 		if (fd == -1) {
+ 			saved_errno = errno;

--- a/ccache/PKGBUILD
+++ b/ccache/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Mateusz Mikuła <mati865@gmail.com>
+
+pkgname=ccache
+pkgver=3.2.4
+pkgrel=1
+pkgdesc="A compiler cache (mingw-w64)"
+arch=('i686' 'x86_64')
+url="https://ccache.samba.org/"
+license=("GPL3")
+replaces=("${pkgname}-git")
+makedepends=("gcc" "pkg-config")
+depends=("gcc-libs" "zlib")
+options=('staticlibs' 'strip')
+source=(https://samba.org/ftp/ccache/${pkgname}-${pkgver}.tar.bz2{,.asc}
+        "MSYS2-dont-use-symlinks.patch")
+sha256sums=('ffeb967edb549e67da0bd5f44f729a2022de9fdde65dfd80d2a7204d7f75332e'
+            'SKIP'
+            'a0d2ea2ef1c9e59d4e5fdd659d291a4c7f4afc48ad50b1bc00f77349337d3167')
+
+prepare() {
+  cd ${pkgname}-${pkgver}
+  #./autogen.sh
+
+  patch -p1 -i ${srcdir}/MSYS2-dont-use-symlinks.patch
+}
+
+build() {
+  [[ -d build-${CHOST} ]] && rm -rf build-${CHOST}
+  mkdir -p build-${CHOST}  && cd build-${CHOST}
+  ../${pkgname}-${pkgver}/configure \
+      --prefix=/usr \
+      --build=${CHOST} \
+      --host=${CHOST} \
+      --target=${CHOST}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  install -d ${pkgdir}/usr/lib/ccache/bin
+  cd ${pkgdir}/usr/lib/ccache/bin
+  scripts=(c++ cc cpp gcc g++ ${CARCH}-pc-msys-g++ ${CARCH}-pc-msys-c++ ${CARCH}-pc-msys-gcc)
+  for fn in ${scripts[*]}; do
+    echo -e '#!/bin/bash\n\nccache /usr/bin/'$fn' "$@"' > $fn
+  done
+}


### PR DESCRIPTION
Ccache for MSYS2.
Thanks to it recompilation with makepkg is much faster also allows to speed up manual recompilation after adding /usr/lib/ccache/bin/ to PATH (`export PATH="/usr/lib/ccache/bin/:$PATH"`).

Normally there would be symlinks to ccache inside /usr/lib/ccache/bin but they don't work out of box in MSYS2. This workaround creates bash scripts executing ccache with proper command.
If someone knows better solution to do it I'll change it. Also if this workaround is acceptable I'll do similar to MinGW ccache package.

EDIT: By the way could some restart tea-ci?
It freeze with `err:seh:setup_exception_record stack overflow 768 bytes in thread 017b eip 611244f9 esp 0060a9e0 stack 0x410000-0x60a9b0-0x610000` in 2 latest commits.