### PR TITLE
Simplify shell shortcuts

### DIFF
--- a/msys2-installer/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
+++ b/msys2-installer/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
@@ -17,21 +17,10 @@ function createShortcuts()
         return;
     }
 
-    var cmdLocation = windir + "\\system32\\cmd.exe";
-    component.addOperation( "CreateShortcut",
-                            cmdLocation,
-                            "@StartMenuDir@/MSYS2 Shell.lnk",
-                            "/A /Q /C " + installer.value("TargetDir") + "\\msys2_shell.bat");
-
-    component.addOperation( "CreateShortcut",
-                            cmdLocation,
-                            "@StartMenuDir@/MinGW-w64 Win32 Shell.lnk",
-                            "/A /Q /C " + installer.value("TargetDir") + "\\mingw32_shell.bat");
-
-    component.addOperation( "CreateShortcut",
-                            cmdLocation,
-                            "@StartMenuDir@/MinGW-w64 Win64 Shell.lnk",
-                            "/A /Q /C " + installer.value("TargetDir") + "\\mingw64_shell.bat");
+    var cmdLocation = installer.value("TargetDir") + "\\start_shell.cmd";
+    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW 32-bit.lnk", "-mingw32");
+    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW 64-bit.lnk", "-mingw64");
+    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MSYS.lnk", "-msys");
 
     if ("@BITNESS@bit" === "32bit") {
         component.addOperation( "Execute",


### PR DESCRIPTION
The shortcuts created by installer are now simplified from this:

```batch
C:\Windows\System32\cmd.exe /A /Q /C C:\MSYS2\msys2_shell.bat
C:\Windows\System32\cmd.exe /A /Q /C C:\MSYS2\mingw32_shell.bat
C:\Windows\System32\cmd.exe /A /Q /C C:\MSYS2\mingw64_shell.bat
```

To this:

```shell
C:\MSYS2\start_shell.cmd -msys
C:\MSYS2\start_shell.cmd -mingw32
C:\MSYS2\start_shell.cmd -mingw64
```