### PR TITLE
New package updpkgver

### DIFF
--- a/updpkgver-git/PKGBUILD
+++ b/updpkgver-git/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Renato Silva <br.renatosilva@gmail.com>
+
+_realname='updpkgver'
+pkgname="${_realname}-git"
+pkgver=r1.d159db2
+pkgrel=1
+pkgdesc='Update recipe version for pacman packages'
+url='https://github.com/renatosilva/updpkgver'
+groups=('base-devel')
+license=(BSD)
+arch=(any)
+
+depends=(pacman wget)
+makedepends=(git)
+provides=(${_realname})
+conflicts=(${_realname})
+source=('git+https://github.com/renatosilva/updpkgver')
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${_realname}"
+    printf "r%s.%s" $(git rev-list --count HEAD) $(git rev-parse --short HEAD)
+}
+
+package() {
+    cd "${srcdir}/${_realname}"
+    install -Dm755 updpkgver.sh "${pkgdir}/usr/bin/updpkgver"
+    install -Dm644 LICENSE      "${pkgdir}/usr/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
This tool searches for new source releases and updates the recipe version automatically. It can be used by package maintainers for keeping recipes up-to-date. Another possible usage is creating update bots that automatically detect and commit buildable upstream releases into the repository. Some examples:

Update maintained packages with analysis report:

```bash
updpkgver --maintainer --report
git diff
```

Update all packages committing successful builds and discarding failed ones:

```bash
updpkgver --commit
updpkgver --reset
```