### PR TITLE
Some improvements for ccache

### DIFF
--- a/ccache/PKGBUILD
+++ b/ccache/PKGBUILD
@@ -1,7 +1,8 @@
 # Maintainer: Mateusz Mikuła <mati865@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 pkgname=ccache
-pkgver=3.2.4
+pkgver=3.2.5
 pkgrel=1
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('i686' 'x86_64')
@@ -11,9 +12,10 @@ replaces=("${pkgname}-git")
 makedepends=("gcc" "pkg-config")
 depends=("gcc-libs" "zlib")
 options=('staticlibs' 'strip')
+install="${pkgname}.install"
 source=(https://samba.org/ftp/ccache/${pkgname}-${pkgver}.tar.bz2{,.asc}
         "MSYS2-dont-use-symlinks.patch")
-sha256sums=('ffeb967edb549e67da0bd5f44f729a2022de9fdde65dfd80d2a7204d7f75332e'
+sha256sums=('7a553809e90faf9de3a23ee9c5b5f786cfd4836bf502744bedb824a24bee1097'
             'SKIP'
             'a0d2ea2ef1c9e59d4e5fdd659d291a4c7f4afc48ad50b1bc00f77349337d3167')
 
@@ -38,11 +40,4 @@ build() {
 package() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
-
-  install -d ${pkgdir}/usr/lib/ccache/bin
-  cd ${pkgdir}/usr/lib/ccache/bin
-  scripts=(c++ cc cpp gcc g++ ${CARCH}-pc-msys-g++ ${CARCH}-pc-msys-c++ ${CARCH}-pc-msys-gcc)
-  for fn in ${scripts[*]}; do
-    echo -e '#!/bin/bash\n\nccache /usr/bin/'$fn' "$@"' > $fn
-  done
 }

--- a/ccache/ccache.install
+++ b/ccache/ccache.install
@@ -1,0 +1,10 @@
+post_install() {
+  mkdir -p /usr/lib/ccache/bin
+  for compiler in c++ cc cpp gcc g++ {i686,x86_64}-{pc-msys,w64-mingw32}-{g++,c++,gcc}; do
+    MSYS='winsymlinks:lnk' ln -sf /usr/bin/ccache /usr/lib/ccache/bin/${compiler}
+  done
+}
+
+pre_remove()   { rm -rf /usr/lib/ccache; }
+pre_upgrade()  { pre_remove; }
+post_upgrade() { post_install; }


### PR DESCRIPTION
The compilers available from system path are now used, and the wrapper scripts have been replaced with symlinks. Fixes #562 and removes the need for mingw-w64-ccache.

* Support both MINGW and MSYS toolchains.
* Fix ccache option for makepkg-mingw.
* Update to 3.2.5.