### PR TITLE
New MSYS package: task

### DIFF
--- a/task/PKGBUILD
+++ b/task/PKGBUILD
@@ -1,0 +1,90 @@
+# Maintainer: Green0Photon <green0photon AT gmail DOT com>
+
+pkgname=task
+pkgver=2.5.1
+pkgrel=1
+pkgdesc="A command-line todo list manager"
+arch=('i686' 'x86_64')
+url="https://taskwarrior.org/"
+license=("MIT")
+
+depends=("gcc-libs"
+         "libgnutls"
+         "libutil-linux"
+         "libhogweed" # for some reason, didn't install with libgnutls
+)
+
+makedepends=("git" # 'msys2-w32api-headers>=5.0.0.4624' 'msys2-w32api-runtime'
+             "gcc"
+             "make"
+             "cmake"
+             "libgnutls-devel"
+             "libutil-linux-devel"
+)
+
+# AUR packages had an odd colon notation
+# The comments were within the quotes so pacman knew about it
+optdepends=("bash-completion" # for bash completion
+            "python" # for python export addon
+            "ruby" # for ruby export addon
+            "perl" # for perl export addon
+            "perl-json" # for perl export addon
+            "rsync" # synchronisation via rsync
+            "curl" # synchronisation via http(s)/ftp
+            "openssh" # synchronisation via ssh
+)
+
+checkdepends=("python" # for tests
+              "bash" # for tests
+)
+
+# This has symlink problems with files missing
+#source=("http://taskwarrior.org/download/${pkgname}-${pkgver}.tar.gz")
+#sha256sums=("d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15")
+
+source=("${pkgname}-${pkgver}::git+https://git.tasktools.org/scm/tm/task.git#tag=v${pkgver}")
+sha256sums=("SKIP")
+
+#prepare() {
+#  pacman -Syu --noconfirm # fix for appveyor old files
+#}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+#  ls "/usr/include/sys"
+#  pacman -Q
+  msg "Starting cmake..."
+  cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=/usr .
+  
+  msg "Starting make..."
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make DESTDIR=$pkgdir install
+
+  # Note that we rename the bash completion script for bash-completion > 1.99, until upstream does so.
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/bash/task.sh" "$pkgdir/usr/share/bash-completion/completions/task"
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/fish/task.fish" "$pkgdir/usr/share/fish/completions/task.fish"
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/zsh/_task" "$pkgdir/usr/share/zsh/site-functions/_task"
+
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/vim/ftdetect/task.vim" "$pkgdir/usr/share/vim/vimfiles/ftdetect/task.vim"
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/vim/syntax/taskdata.vim" "$pkgdir/usr/share/vim/vimfiles/syntax/taskdata.vim"
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/vim/syntax/taskedit.vim" "$pkgdir/usr/share/vim/vimfiles/syntax/taskedit.vim"
+  install -Dm644 "$pkgdir/usr/share/doc/task/scripts/vim/syntax/taskrc.vim" "$pkgdir/usr/share/vim/vimfiles/syntax/taskrc.vim"
+
+  install -Dm644 "$srcdir/$pkgname-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/task/LICENSE"
+}
+
+check() {
+  cd "${srcdir}/${pkgname}-${pkgver}/test"
+  
+  msg "Starting make for testing..."
+  make
+  
+  msg "Running tests (Please be patient)..."
+  ./run_all || true
+  msg "Results:"
+  ./python problems || true
+}


### PR DESCRIPTION
This is a command line productivity tool also called [Taskwarrior](https://taskwarrior.org/). It is a highly flexible open source todo list.

It has no support for Windows, so it's on Cygwin.

I'm not an official maintainer or anything, but a user who wanted to use taskwarrior on MSYS2 rather than Cygwin. Dependencies were tested on my MSYS2-x86_64. I borrowed pieces from the official Arch package and the git AUR package, in addition to adding testing.

There are two oddities: the official tar has broken symlinks which causes makepkg to fail, so I download the git repo and switch to the tag instead. In addition, task originally crashes when run, because libgnutls did not install libhogweed, so that is included as a dependency.

The tests has a few failures (out of roughly a thousand), but I suspect those are normal. I can install a linux vm to compare, if you want, but it works. After skimming through the tests, the failure seemed inconsequential, or even false failures. I have the check function set to succeed regardless.

I also plan on making packages for the other taskwarrior tools (taskd, vit, and tasksh). They will be (a) separate pull request(s). I will probably put them all together in one pull request instead, but I want to get this into repo. If you don't pull this by the time I make the other packages, I'll merge them into this pull request.

Thanks!