### PR TITLE
Fixes for continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,14 @@ environment:
     BUILD_URL: https://ci.appveyor.com/project/$(APPVEYOR_ACCOUNT_NAME)/$(APPVEYOR_PROJECT_NAME)/build/$(APPVEYOR_BUILD_VERSION)
 
 build_script:
-    # TODO: implement update-core --noconfirm and replace the below command line
-    - C:\msys64\usr\bin\pacman --sync --refresh --refresh --needed --noconfirm msys2-runtime msys2-runtime-devel bash pacman pacman-mirrors
+    # TODO: remove the line below once the AppVeyor installation includes a
+    # newer version of pacman that can perform core updates
+    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh pacman
+
+    # Git is required but currently not part of AppVeyor installation
+    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh git
+
+    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
     - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+    MSYSTEM: MSYS
     DEPLOY_PROVIDER: bintray
     BINTRAY_ACCOUNT: alexpux
     BINTRAY_REPOSITORY: msys2

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -26,7 +26,7 @@ execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refre
 for package in "${packages[@]}"; do
     execute 'Building binary' makepkg --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource
-    yes|execute 'Installing' pacman --noprogressbar --upgrade *.pkg.tar.xz
+    execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.xz
     deploy_enabled && mv "${package}"/*.pkg.tar.xz artifacts
     deploy_enabled && mv "${package}"/*.src.tar.gz artifacts
     unset package

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -22,7 +22,7 @@ define_build_order || failure 'Could not determine build order'
 
 # Build
 message 'Building packages' "${packages[@]}"
-execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade
+execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade --sysupgrade
 for package in "${packages[@]}"; do
     execute 'Building binary' makepkg --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -118,10 +118,14 @@ git_config() {
 # Run command with status
 execute(){
     local status="${1}"
-    local command=("${@:2}")
+    local command="${2}"
+    local arguments=("${@:3}")
     cd "${package:-.}"
     message "${status}"
-    ${command[@]} || failure "${status} failed"
+    if [[ "${command}" != *:* ]]
+        then ${command} ${arguments[@]}
+        else ${command%%:*} | ${command#*:} ${arguments[@]}
+    fi || failure "${status} failed"
     cd - > /dev/null
 }
 


### PR DESCRIPTION
* Fix the incomplete system update in AppVeyor after new pacman extended the core package list and the explicit references became outdated. This was causing the core update to be completed only in ci-build script, and the regular update to be left behind. For example, #575 seems to have reproduced the problem.

* Fix failure detection for package installation, avoiding false positives like [MINGW-packages#1376](https://github.com/Alexpux/MINGW-packages/pull/1376).

* Explicitly set a default shell in AppVeyor, avoiding failures like reproduced by #587.

* Package downgrades are now enabled for regular updates and for AppVeyor core updates, so removed versions are properly detected.

* Git is now explicitly installed in AppVeyor since the external one is not anymore visible after minimal path has been implemented.