### PR TITLE
Fixes for winpty

### DIFF
--- a/winpty-git/0002-fix-path-conversion.patch
+++ b/winpty-git/0002-fix-path-conversion.patch
@@ -1,0 +1,66 @@
+diff -aurN 0001/src/unix-adapter/main.cc 0002/src/unix-adapter/main.cc
+--- 0001/src/unix-adapter/main.cc
++++ 0002/src/unix-adapter/main.cc
+@@ -47,6 +47,7 @@
+ #include "OutputHandler.h"
+ #include "Util.h"
+ #include "WakeupFd.h"
++#include "path_conv.h"
+ 
+ #define CSI "\x1b["
+ 
+@@ -154,7 +155,12 @@
+     char *tmp;
+ #if defined(CYGWIN_VERSION_CYGWIN_CONV) && \
+         CYGWIN_VERSION_API_MINOR >= CYGWIN_VERSION_CYGWIN_CONV
+-    // MSYS2 and versions of Cygwin released after 2009 or so use this API.
++#if defined(__MSYS__)
++    size_t newSize = 256 * MAX_PATH;
++    tmp = new char[newSize + 1];
++    convert(tmp, newSize, path.c_str());
++#else
++    // Versions of Cygwin released after 2009 or so use this API.
+     // The original MSYS still lacks this API.
+     ssize_t newSize = cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_RELATIVE,
+                                        path.c_str(), NULL, 0);
+@@ -163,6 +169,7 @@
+     ssize_t success = cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_RELATIVE,
+                                        path.c_str(), tmp, newSize + 1);
+     assert(success == 0);
++#endif
+ #else
+     // In the current Cygwin header file, this API is documented as deprecated
+     // because it's restricted to paths of MAX_PATH length.  In the CVS version
+@@ -173,10 +180,6 @@
+     tmp = new char[MAX_PATH + path.size()];
+     cygwin_conv_to_win32_path(path.c_str(), tmp);
+ #endif
+-    for (int i = 0; tmp[i] != '\0'; ++i) {
+-        if (tmp[i] == '/')
+-            tmp[i] = '\\';
+-    }
+     std::string ret(tmp);
+     delete [] tmp;
+     return ret;
+diff -aurN 0001/src/unix-adapter/path_conv.cc 0002/src/unix-adapter/path_conv.cc
+--- 0001/src/unix-adapter/path_conv.cc
++++ 0002/src/unix-adapter/path_conv.cc
+@@ -633,7 +633,6 @@
+         one_path[to-from] = '\0';
+         char win32_path1[PATH_MAX + 1];
+         ssize_t result = cygwin_conv_path(CCP_POSIX_TO_WIN_A|CCP_ABSOLUTE, one_path, win32_path1, PATH_MAX+1);
+-        printf("called cygwin_conv_path(CCP_POSIX_TO_WIN_A,%s -> %s, in-size %d, result = %zd\n", one_path, win32_path1, PATH_MAX+1, result);
+         if( result !=0 ) {
+             copy_to_dst(one_path, NULL, dst, dstend);
+         } else {
+diff -aurN 0001/src/unix-adapter/subdir.mk 0002/src/unix-adapter/subdir.mk
+--- 0001/src/unix-adapter/subdir.mk
++++ 0002/src/unix-adapter/subdir.mk
+@@ -28,6 +28,7 @@
+ 	build/unix-adapter/unix-adapter/Util.o \
+ 	build/unix-adapter/unix-adapter/WakeupFd.o \
+ 	build/unix-adapter/unix-adapter/main.o \
++	build/unix-adapter/unix-adapter/path_conv.o \
+ 	build/unix-adapter/shared/DebugClient.o \
+ 	build/unix-adapter/shared/WinptyAssert.o \
+ 	build/unix-adapter/shared/WinptyVersion.o

--- a/winpty-git/PKGBUILD
+++ b/winpty-git/PKGBUILD
@@ -1,35 +1,58 @@
 # Maintainer: Martell Malone <martell malone at g mail dot com>
 # Contributor: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: David Macek <david.macek.0@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=winpty
 pkgname="${_realname}-git"
 epoch=1
-pkgver=0.2.2.374.ccbdaf7
+pkgver=0.3.0.429.671360a
 pkgrel=1
 pkgdesc="A Windows software package providing an interface similar to a Unix pty-master for communicating with Windows console programs"
 arch=('i686' 'x86_64')
 url="https://github.com/rprichard/winpty"
 license=("MIT")
-makedepends=("git" "tar" "automake" "xz"
-             "mingw-w64-cross-gcc")
+
+# Explicitly reference the git version of the indirect dependency mingw-w64-cross-crt
+# for avoiding problems with its default provider mingw-w64-cross-crt-clang-git
+makedepends=(git tar automake xz
+             mingw-w64-cross-gcc
+             mingw-w64-cross-crt-git)
+
 provides=("${_realname}")
 conflicts=("${_realname}")
 #depends=( "ncurses-devel" )
 options=('staticlibs' 'strip')
+
+# TODO: Replace path_conv with arg_heuristic from MSYS2 runtime
+#       See https://github.com/rprichard/winpty/issues/56
 source=("${_realname}"::"git+https://github.com/rprichard/winpty.git"
-        0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch)
+        path_conv.cc::'https://github.com/Alexpux/path_convert/raw/master/src/path_conv.cpp'
+        path_conv.h::'https://github.com/Alexpux/path_convert/raw/master/src/path_conv.h'
+        0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch
+        0002-fix-path-conversion.patch)
+
 sha256sums=('SKIP'
-            'c9705d86feba11f1155e4259d28131afb14db3c30c17efe96bdd655afa72ee04')
+            '7181d260592dc193f235965f202a5509b113d8b478efae3f06176b8625b683cc'
+            'c84e4edc5a1e387dc1ea06445db76a7bfe43e816f0c32558ce8d8562378d5782'
+            'c9705d86feba11f1155e4259d28131afb14db3c30c17efe96bdd655afa72ee04'
+            '4427afccf0b648d3bc1aa7442b0f611674efd91474fee48f7bf842194d6cea4f')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
   printf "%s.%s.%s" "$(cat VERSION.txt)" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
+consolidate() {
+  cp ../path_conv.cc src/unix-adapter/path_conv.cc
+  cp ../path_conv.h  src/unix-adapter/path_conv.h
+}
+
 prepare() {
   cd "${srcdir}/${_realname}"
-  git am ${srcdir}/0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch
+  consolidate
+  patch -p1 -i ${srcdir}/0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch
+  patch -p1 -i ${srcdir}/0002-fix-path-conversion.patch
 }
 
 build() {

--- a/winpty/0002-fix-path-conversion.patch
+++ b/winpty/0002-fix-path-conversion.patch
@@ -1,0 +1,66 @@
+diff -aurN 0001/src/unix-adapter/main.cc 0002/src/unix-adapter/main.cc
+--- 0001/src/unix-adapter/main.cc
++++ 0002/src/unix-adapter/main.cc
+@@ -47,6 +47,7 @@
+ #include "OutputHandler.h"
+ #include "Util.h"
+ #include "WakeupFd.h"
++#include "path_conv.h"
+ 
+ #define CSI "\x1b["
+ 
+@@ -154,7 +155,12 @@
+     char *tmp;
+ #if defined(CYGWIN_VERSION_CYGWIN_CONV) && \
+         CYGWIN_VERSION_API_MINOR >= CYGWIN_VERSION_CYGWIN_CONV
+-    // MSYS2 and versions of Cygwin released after 2009 or so use this API.
++#if defined(__MSYS__)
++    size_t newSize = 256 * MAX_PATH;
++    tmp = new char[newSize + 1];
++    convert(tmp, newSize, path.c_str());
++#else
++    // Versions of Cygwin released after 2009 or so use this API.
+     // The original MSYS still lacks this API.
+     ssize_t newSize = cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_RELATIVE,
+                                        path.c_str(), NULL, 0);
+@@ -163,6 +169,7 @@
+     ssize_t success = cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_RELATIVE,
+                                        path.c_str(), tmp, newSize + 1);
+     assert(success == 0);
++#endif
+ #else
+     // In the current Cygwin header file, this API is documented as deprecated
+     // because it's restricted to paths of MAX_PATH length.  In the CVS version
+@@ -173,10 +180,6 @@
+     tmp = new char[MAX_PATH + path.size()];
+     cygwin_conv_to_win32_path(path.c_str(), tmp);
+ #endif
+-    for (int i = 0; tmp[i] != '\0'; ++i) {
+-        if (tmp[i] == '/')
+-            tmp[i] = '\\';
+-    }
+     std::string ret(tmp);
+     delete [] tmp;
+     return ret;
+diff -aurN 0001/src/unix-adapter/path_conv.cc 0002/src/unix-adapter/path_conv.cc
+--- 0001/src/unix-adapter/path_conv.cc
++++ 0002/src/unix-adapter/path_conv.cc
+@@ -633,7 +633,6 @@
+         one_path[to-from] = '\0';
+         char win32_path1[PATH_MAX + 1];
+         ssize_t result = cygwin_conv_path(CCP_POSIX_TO_WIN_A|CCP_ABSOLUTE, one_path, win32_path1, PATH_MAX+1);
+-        printf("called cygwin_conv_path(CCP_POSIX_TO_WIN_A,%s -> %s, in-size %d, result = %zd\n", one_path, win32_path1, PATH_MAX+1, result);
+         if( result !=0 ) {
+             copy_to_dst(one_path, NULL, dst, dstend);
+         } else {
+diff -aurN 0001/src/unix-adapter/subdir.mk 0002/src/unix-adapter/subdir.mk
+--- 0001/src/unix-adapter/subdir.mk
++++ 0002/src/unix-adapter/subdir.mk
+@@ -26,6 +26,7 @@
+ 	build/unix/unix-adapter/Util.o \
+ 	build/unix/unix-adapter/WakeupFd.o \
+ 	build/unix/unix-adapter/main.o \
++	build/unix/unix-adapter/path_conv.o \
+ 	build/unix/shared/DebugClient.o \
+ 	build/unix/shared/WinptyVersion.o
+ 

--- a/winpty/PKGBUILD
+++ b/winpty/PKGBUILD
@@ -1,28 +1,51 @@
 # Maintainer: Martell Malone <martell malone at g mail dot com>
 # Contributor: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: David Macek <david.macek.0@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=winpty
 pkgname="${_realname}"
 pkgver=0.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A Windows software package providing an interface similar to a Unix pty-master for communicating with Windows console programs"
 arch=('i686' 'x86_64')
 url="https://github.com/rprichard/winpty"
 license=('MIT')
-makedepends=("git" "tar" "automake" "xz"
-             "mingw-w64-cross-gcc")
+
+# Explicitly reference the git version of the indirect dependency mingw-w64-cross-crt
+# for avoiding problems with its default provider mingw-w64-cross-crt-clang-git
+makedepends=(git tar automake xz
+             mingw-w64-cross-gcc
+             mingw-w64-cross-crt-git)
+
 #depends=( "ncurses-devel" )
 replaces=("winpty-git")
 options=('staticlibs' 'strip')
+
+# TODO: Replace path_conv with arg_heuristic from MSYS2 runtime
+#       See https://github.com/rprichard/winpty/issues/56
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rprichard/${_realname}/archive/${pkgver}.tar.gz"
-        0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch)
+        path_conv.cc::'https://github.com/Alexpux/path_convert/raw/master/src/path_conv.cpp'
+        path_conv.h::'https://github.com/Alexpux/path_convert/raw/master/src/path_conv.h'
+        0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch
+        0002-fix-path-conversion.patch)
+
 sha256sums=('93be4dd7272e72c9000dabf70c3a97bf72224f2df2833e217d6ee7b77770e517'
-            'c9705d86feba11f1155e4259d28131afb14db3c30c17efe96bdd655afa72ee04')
+            '7181d260592dc193f235965f202a5509b113d8b478efae3f06176b8625b683cc'
+            'c84e4edc5a1e387dc1ea06445db76a7bfe43e816f0c32558ce8d8562378d5782'
+            'c9705d86feba11f1155e4259d28131afb14db3c30c17efe96bdd655afa72ee04'
+            '451c61a2fc15411c72359f3c5a4b2b6e524091b3ac910103dfa5df48f8ee8782')
+
+consolidate() {
+  cp ../path_conv.cc src/unix-adapter/path_conv.cc
+  cp ../path_conv.h  src/unix-adapter/path_conv.h
+}
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  consolidate
   patch -p1 -i ${srcdir}/0001-Apply-POSIX-to-Win-conversion-on-all-arguments-on-MSYS.patch
+  patch -p1 -i ${srcdir}/0002-fix-path-conversion.patch
 }
 
 build() {


### PR DESCRIPTION
Fix path conversion from unix to Windows format, and a build problem caused by mingw-w64-cross-crt-clang-git. Conversion example:

```
$ winpty cmd //c echo //path is /path
/path is C:/MSYS2/path
```