### PR TITLE
gdb: fix path for gcc-5.3.0 libstdcxx

### DIFF
--- a/gdb/PKGBUILD
+++ b/gdb/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=gdb
 pkgver=7.9
-pkgrel=1
-_gcc_ver=4.9.2
+pkgrel=2
+_gcc_ver=5.3.0
 pkgdesc="GNU Debugger (MSYS2 version)"
 arch=('i686' 'x86_64')
 license=('GPL3')


### PR DESCRIPTION
Fixes importError:
 ```
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  ImportError: No module named libstdcxx.v6.printers
  /etc/gdbinit:6: Error in sourced command file:
  Error while executing Python code.
```