### PR TITLE
Upgrade Subversion to 1.9.4

### DIFF
--- a/subversion/PKGBUILD
+++ b/subversion/PKGBUILD
@@ -9,7 +9,7 @@ url="https://subversion.apache.org/"
 license=('APACHE')
 groups=('VCS')
 depends=('libsqlite' 'file' 'libserf' 'libsasl')
-makedepends=('python2' 'perl' 'swig' 'ruby' 'libsqlite-devel' 'libserf-devel' 'libsasl-devel')
+makedepends=('python2' 'perl' 'swig' 'ruby' 'libsqlite-devel' 'libserf-devel' 'libsasl-devel' 'gmp-devel')
 optdepends=('bash-completion: for svn bash completion'
             'python2: for some hook scripts'
             'ruby: for some hook scripts')

--- a/subversion/PKGBUILD
+++ b/subversion/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=subversion
-pkgver=1.9.3
-pkgrel=2
+pkgver=1.9.4
+pkgrel=1
 pkgdesc="A Modern Concurrent Version Control System"
 arch=('i686' 'x86_64')
 url="https://subversion.apache.org/"
@@ -40,7 +40,7 @@ source=(https://archive.apache.org/dist/subversion/subversion-${pkgver}.tar.bz2{
         subversion-1.9.1-msys2.patch
         remove-checking-symlink.patch
         90-use-copy-instead-symlink.patch)
-sha256sums=('8bbf6bb125003d88ee1c22935a36b7b1ab7d957e0c8b5fbfe5cb6310b6e86ae0'
+sha256sums=('1267f9e2ab983f260623bee841e6c9cc458bf4bf776238ed5f100983f79e9299'
             'SKIP'
             'b09dd041aba0078c8d50df130ef2f96c3ef8486279a620532fef4fe48ef9961e'
             'cc0367818850e39ccaaeacf6df77303a6ec180017455d7b10c6c68ea024d4e6f'


### PR DESCRIPTION
I am grappling with a problem (the infamous Win32 error 1114) when loading `msys-svn_subr-1.0.dll` and while at it, I realized that a new Subversion version was released. Might just as well upgrade ;-)