### PR TITLE
Fix rsync build

### DIFF
--- a/rsync/PKGBUILD
+++ b/rsync/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=rsync
 pkgver=3.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A file transfer program to keep remote files in sync"
 arch=('i686' 'x86_64')
 url="https://rsync.samba.org"
@@ -10,12 +10,10 @@ groups=('net-utils')
 license=('GPL3')
 depends=('perl')
 source=("https://rsync.samba.org/ftp/rsync/$pkgname-$pkgver.tar.gz"
-        "https://rsync.samba.org/ftp/rsync/$pkgname-$pkgver.tar.gz.asc"
         rsync-3.1.0-msys2.patch
         ssh-6-option.patch)
 sha256sums=('ecfa62a7fa3c4c18b9eccd8c16eaddee4bd308a76ea50b5c02a5840f09c0a1c2'
-            'SKIP'
-            'f7dfeb7162abafb3a6bd58d3df23ec0519df4a8c0b6ebb28592844468d5f9ce6'
+            '4fee5ba148b2fb4cd910f75e0271f5d66854954cbfaa34a6d9b814de9af2fb05'
             'ea88046d8935e7a597cca7379d21edffefa520792d896bd7ce663b4cdc0f2069')
 
 prepare() {

--- a/rsync/rsync-3.1.0-msys2.patch
+++ b/rsync/rsync-3.1.0-msys2.patch
@@ -46,7 +46,7 @@ diff -Naur rsync-3.0.9-orig/configure.ac rsync-3.0.9/configure.ac
  	AC_DEFINE(SUPPORT_ACLS, 1, [Define to 1 to add support for ACLs])
  	;;
 -    solaris*|*cygwin*)
-+    solaris*|*cygwin*|*msys*)
++    solaris*)
  	AC_MSG_RESULT(Using solaris ACLs)
  	AC_DEFINE(HAVE_SOLARIS_ACLS, 1, [true if you have solaris ACLs])
  	AC_DEFINE(SUPPORT_ACLS, 1)
@@ -85,7 +85,7 @@ diff -Naur rsync-3.1.0-orig/configure.sh rsync-3.1.0/configure.sh
  
  	;;
 -    solaris*|*cygwin*)
-+    solaris*|*cygwin*|*msys*)
++    solaris*)
  	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: Using solaris ACLs" >&5
  $as_echo "Using solaris ACLs" >&6; }
  


### PR DESCRIPTION
Because of this commit https://github.com/mirror/newlib-cygwin/commit/9ddf063921f5202100f8e36bb451ae5ac9f76d37 rysnc should use to POSIX ACL
This commit lets it be auto detected rather than hard code it to use SOLARIS_ACLS