### PR TITLE
Updates for continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,6 @@ environment:
     BUILD_URL: https://ci.appveyor.com/project/$(APPVEYOR_ACCOUNT_NAME)/$(APPVEYOR_PROJECT_NAME)/build/$(APPVEYOR_BUILD_VERSION)
 
 build_script:
-    # TODO: remove the line below once the AppVeyor installation includes a
-    # newer version of pacman that can perform core updates
-    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh pacman
-
-    # Git is required but currently not part of AppVeyor installation
-    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh git
-
     - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
     - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
 


### PR DESCRIPTION
AppVeyor has [recently updated](https://github.com/appveyor/ci/issues/765) the MSYS2 installation, so manual installation of git and latest pacman is not necessary anymore.