### PR TITLE
Adjustment for shell starter

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=filesystem
 pkgver=2016.05
-pkgrel=2
+pkgrel=3
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -54,7 +54,7 @@ sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
             '50c3746d621e682e3560e1b37cc1ac5d988460064a20ed15f107c203ac5ad622'
             '9620bdf1c82ea3f14c3553c44a2006ea61ff3f5a775a2a053130a59cc186daf5'
             '7d6994d7caf52a459b562cfb0da1d758a4b7bca478d1df00de3a96686e59008e'
-            '58ed2b684334c695abba15a11cc0b9f6ab58477fccb00635564a66d8091b2f0c'
+            '45bdfd620e81e6c0ff0bc0e7d9fa1bc4efebe7382c37e8affc29e306fe3fe7b7'
             'dbad95826d6302294aa7cfbafdefb8ef86b12388e3ac419fc55326cc4e2fc7fe'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
             'ddad06e5a36dc501356d585154eabb755af20a4e26f1aa6709d6282feee41866'

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -26,8 +26,10 @@ if "x%~1" == "x-help" (
 )
 rem Shell types
 if "x%~1" == "x-msys" shift& set MSYSTEM=MSYS& goto :checkparams
+if "x%~1" == "x-msys2" shift& set MSYSTEM=MSYS& set _deprecated_msys2=true& goto :checkparams
 if "x%~1" == "x-mingw32" shift& set MSYSTEM=MINGW32& goto :checkparams
 if "x%~1" == "x-mingw64" shift& set MSYSTEM=MINGW64& goto :checkparams
+if "x%~1" == "x-mingw" shift& set _deprecated_mingw=true& (if exist "%WD%..\..\mingw64" (set MSYSTEM=MINGW64) else (set MSYSTEM=MINGW32))& goto :checkparams
 rem Console types
 if "x%~1" == "x-consolez" shift& set MSYSCON=console.exe& goto :checkparams
 if "x%~1" == "x-mintty" shift& set MSYSCON=mintty.exe& goto :checkparams
@@ -43,12 +45,20 @@ if "x%CHERE_INVOKING%" == "xenabled_from_arguments" if not "%~1" == "" if exist 
 rem Deprecated parameters
 rem TODO: remove this check when most users have stopped using them
 if "x%_deprecated_use_full_path%" == "xtrue" (
-  echo The MSYS2 shell has been started with the deprecated -use-full-path> "%WD%..\..\etc\profile.d\use_full_path.warning.once"
-  echo option. Please update your shortcuts to use -full-path instead.>>    "%WD%..\..\etc\profile.d\use_full_path.warning.once"
+  echo The MSYS2 shell has been started with the deprecated -use-full-path> "%WD%..\..\etc\profile.d\msys2_shell.use_full_path.warning.once"
+  echo option. Please update your shortcuts to use -full-path instead.>>    "%WD%..\..\etc\profile.d\msys2_shell.use_full_path.warning.once"
 )
 if "x%_deprecated_where%" == "xtrue" (
-  echo The MSYS2 shell has been started with the deprecated -where> "%WD%..\..\etc\profile.d\where.warning.once"
-  echo option. Please update your shortcuts to use -here instead.>> "%WD%..\..\etc\profile.d\where.warning.once"
+  echo The MSYS2 shell has been started with the deprecated -where> "%WD%..\..\etc\profile.d\msys2_shell.where.warning.once"
+  echo option. Please update your shortcuts to use -here instead.>> "%WD%..\..\etc\profile.d\msys2_shell.where.warning.once"
+)
+if "x%_deprecated_msys2%" == "xtrue" (
+  echo The MSYS2 shell has been started with the deprecated -msys2> "%WD%..\..\etc\profile.d\msys2_shell.msys2.warning.once"
+  echo option. Please update your shortcuts to use -msys instead.>> "%WD%..\..\etc\profile.d\msys2_shell.msys2.warning.once"
+)
+if "x%_deprecated_mingw%" == "xtrue" (
+  echo The MSYS2 shell has been started with the deprecated -mingw option.> "%WD%..\..\etc\profile.d\msys2_shell.mingw.warning.once"
+  echo Please update your shortcuts to use -mingw32 or -mingw64 instead.>>  "%WD%..\..\etc\profile.d\msys2_shell.mingw.warning.once"
 )
 
 rem Setup proper title


### PR DESCRIPTION
Restore the -mingw and -msys2 parameters as deprecated, since some users may be using them. For example see #623.