### PR TITLE
bashisms: remove arrays [+fix pinentry build]

### DIFF
--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gnupg
 pkgver=1.4.20
-pkgrel=1
+pkgrel=2
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 url='https://gnupg.org/'
 license=('GPL')

--- a/gnupg/gnupg.install
+++ b/gnupg/gnupg.install
@@ -1,5 +1,5 @@
 info_dir=usr/share/info
-info_files=(gnupg1.info)
+info_files="gnupg1.info"
 
 post_install() {
   [ -x usr/bin/install-info ] || return 0
@@ -18,7 +18,7 @@ post_upgrade() {
 
 pre_remove() {
   [ -x usr/bin/install-info ] || return 0
-  for f in ${info_files[@]}; do
+  for f in $info_files; do
     usr/bin/install-info --delete ${info_dir}/$f.gz ${info_dir}/dir 2> /dev/null
   done
 }

--- a/pinentry/PKGBUILD
+++ b/pinentry/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pinentry
 pkgver=0.9.7
-pkgrel=1
+pkgrel=2
 pkgdesc='A collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol'
 url='https://gnupg.org/related_software/pinentry/'
 license=('GPL')

--- a/pinentry/PKGBUILD
+++ b/pinentry/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=pinentry
 pkgver=0.9.7
-pkgrel=2
+pkgrel=3
 pkgdesc='A collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol'
 url='https://gnupg.org/related_software/pinentry/'
 license=('GPL')
 arch=('i686' 'x86_64')
-makedepends=('ncurses-devel')
-depends=('ncurses')
+makedepends=('ncurses-devel' 'libassuan-devel' 'libgpg-error-devel')
+depends=('ncurses' 'libassuan' 'libgpg-error')
 source=(https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2{,.sig}
         pinentry-0.9.1-msysize.patch)
 install=pinentry.install

--- a/pinentry/pinentry.install
+++ b/pinentry/pinentry.install
@@ -1,5 +1,5 @@
 info_dir=usr/share/info
-info_files=(pinentry.info)
+info_files="pinentry.info"
 
 post_install() {
   [ -x usr/bin/install-info ] || return 0
@@ -14,7 +14,7 @@ post_upgrade() {
 
 pre_remove() {
   [ -x usr/bin/install-info ] || return 0
-  for f in ${info_files[@]}; do
+  for f in $info_files; do
     usr/bin/install-info --delete ${info_dir}/$f.gz ${info_dir}/dir 2> /dev/null
   done
 }


### PR DESCRIPTION
A couple more have crept in since c3d40c1afe76810bdbb49e35f369279157fd4653.