### PR TITLE
Update pactoys

### DIFF
--- a/pactoys-git/PKGBUILD
+++ b/pactoys-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname='pactoys'
 pkgname="${_realname}-git"
-pkgver=r1.e58a7ac
+pkgver=r1.2836307
 pkgrel=1
 pkgdesc='A set of pacman packaging utilities'
 url='https://github.com/renatosilva/pactoys'
@@ -25,21 +25,11 @@ pkgver() {
 }
 
 build() {
-    cd "${srcdir}/${_realname}/repman/native"
+    cd "${srcdir}/${_realname}"
     make
 }
 
 package() {
     cd "${srcdir}/${_realname}"
-    mkdir -p "${pkgdir}/var/cache/pacboy"
-
-    install -Dm755 makepatch/makepatch.sh          "${pkgdir}/usr/bin/makepatch"
-    install -Dm755 pacboy/pacboy.sh                "${pkgdir}/usr/bin/pacboy"
-    install -Dm755 repman/native/repman.exe        "${pkgdir}/usr/bin/repman.exe"
-    install -Dm755 saneman/saneman.sh              "${pkgdir}/usr/bin/saneman"
-    install -Dm755 updpkgver/updpkgver.sh          "${pkgdir}/usr/bin/updpkgver"
-
-    install -Dm644 pacboy/pacboy.completion        "${pkgdir}/usr/share/bash-completion/completions/pacboy"
-    install -Dm644 LICENSE                         "${pkgdir}/usr/share/licenses/${_realname}/LICENSE"
-    install -Dm644 repman/native/inih/LICENSE.txt  "${pkgdir}/usr/share/licenses/${_realname}/inih/LICENSE"
+    make DESTDIR="${pkgdir}" install
 }


### PR DESCRIPTION
This features a new version of saneman:

![saneman](https://cloud.githubusercontent.com/assets/1465469/16214443/9f65d276-372e-11e6-8c2c-82d73a692889.png)

And a bash library originated from code refactoring:

```bash
source pactoys
import colorize
import path_to_list
import recipe_info
import warning

colorize
path_to_list directories "${PATH}"

for directory in "${directories[@]}"; do
    test -d "${directory}" || warning "missing ${directory}"
done

recipe_info PKGBUILD pkgname license
echo "${pkgname} is licensed under ${license}"
```