### PR TITLE
Improvements for continuous integration

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -20,6 +20,10 @@ message 'Processing changes' "${commits[@]}"
 test -z "${packages}" && success 'No changes in package recipes'
 define_build_order || failure 'Could not determine build order'
 
+# Quality
+message 'Checking recipe quality'
+check_recipe_quality || failure 'Could not pass quality check'
+
 # Build
 message 'Building packages' "${packages[@]}"
 execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade --sysupgrade

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -182,6 +182,11 @@ list_packages() {
     return 0
 }
 
+# Recipe quality
+check_recipe_quality() {
+    saneman --format='\t%l:%c %p:%c %m' --verbose --no-terminal "${packages[@]}"
+}
+
 # Status functions
 failure() { local status="${1}"; local items=("${@:2}"); _status failure "${status}." "${items[@]}"; exit 1; }
 success() { local status="${1}"; local items=("${@:2}"); _status success "${status}." "${items[@]}"; exit 0; }


### PR DESCRIPTION
Saneman is now used for checking recipe quality, causing build failures for example when packages depends on themselves for runtime, and reporting problems like deprecated checksums, unrecognized licenses or mismatching directories. Requires #639.

![saneman-ci](https://cloud.githubusercontent.com/assets/1465469/16342880/ba5c77ea-3a0a-11e6-8da4-a865b14f5370.png)