### PR TITLE
Fix to missing closing paran in FindBoost.cmake

### DIFF
--- a/cmake/PKGBUILD
+++ b/cmake/PKGBUILD
@@ -31,7 +31,7 @@ source=("https://www.cmake.org/files/v3.5/${pkgname}-${pkgver}.tar.gz"
         "3.5.2-cpuinfo.patch"
         "3.5.2-cygwin-paths.patch")
 sha256sums=('92d8410d3d981bb881dfff2aed466da55a58d34c7390d50449aa59b32bb5e62a'
-            '17ea1358116b4fd22b4ad372c24202058e374a97d967284fcc768d494c539e2c'
+            '0eeb8fa8d08c25b35cd674ed1dac3998eefaa6195a0b5efebcb08bf547e691d3'
             'b7e398e70b97088f88a0688e8a0794d6780d3cdb91075388a30908dc4b405eb7'
             '98dca846de0ca7b71884e26678317f85e78e01862d58a29ce923c835ca7d614f'
             '4f312510b45774ef299982ea112efbae4ef89cc680a7e4a14f2d1cf619b9749c'

--- a/cmake/PKGBUILD
+++ b/cmake/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cmake
 pkgver=3.5.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system"
 arch=('i686' 'x86_64')
 url="https://www.cmake.org/"

--- a/cmake/cmake-3.5.2-msys.patch
+++ b/cmake/cmake-3.5.2-msys.patch
@@ -386,7 +386,7 @@ diff -aur cmake-3.5.2/Modules/FindBoost.cmake.orig cmake-3.5.2/Modules/FindBoost
  set(Boost_LIB_PREFIX "")
  if ( (GHSMULTI AND Boost_USE_STATIC_LIBS) OR
 -    (WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN) )
-+    ( WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN AND NOT MSYS)
++    ( WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN AND NOT MSYS) )
    set(Boost_LIB_PREFIX "lib")
  endif()
  


### PR DESCRIPTION
patch stripped a needed closing paran causing cmake builds that use boost to fail
