### PR TITLE
subversion: avoid stack corruption in script bindings

### DIFF
--- a/subversion/20-fix-stack-corruption-in-swig-wrappers.patch
+++ b/subversion/20-fix-stack-corruption-in-swig-wrappers.patch
@@ -1,0 +1,60 @@
+From a074af86c8764404b28ce99d0bedcb668a321408 Mon Sep 17 00:00:00 2001
+From: Roderich Schupp <rschupp@apache.org>
+Date: Wed, 3 Jun 2015 09:50:59 +0000
+Subject: [PATCH] * subversion/bindings/swig/include/svn_types.swg:   Bracket
+ calls with PUTBACK/SPAGAIN to helper functions   that call back into Perl:  
+ - svn_swig_pl_make_stream   - svn_swig_pl_from_stream   -
+ svn_swig_pl_from_md5   Note: calls in typemaps need only SPAGAIN.
+
+git-svn-id: https://svn.apache.org/repos/asf/subversion/trunk@1683266 13f79535-47bb-0310-9956-ffa450edef68
+---
+ subversion/bindings/swig/include/svn_types.swg | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/subversion/bindings/swig/include/svn_types.swg b/subversion/bindings/swig/include/svn_types.swg
+index 31b3e9b..1617743 100644
+--- a/subversion/bindings/swig/include/svn_types.swg
++++ b/subversion/bindings/swig/include/svn_types.swg
+@@ -935,15 +935,24 @@ svn_ ## TYPE ## _swig_rb_closed(VALUE self)
+ #ifdef SWIGPERL
+ %typemap(in) svn_stream_t * {
+     svn_swig_pl_make_stream (&$1, $input);
++    SPAGAIN;
+ }
+ 
+ %typemap(out) svn_stream_t * {
+-    $result = svn_swig_pl_from_stream ($1);
++    SV* tmp;
++    PUTBACK;
++    tmp = svn_swig_pl_from_stream ($1);
++    SPAGAIN;
++    $result = tmp;
+     argvi++;
+ }
+ 
+ %typemap(argout) svn_stream_t ** {
+-  %append_output(svn_swig_pl_from_stream(*$1));
++    SV *tmp;
++    PUTBACK;
++    tmp = svn_swig_pl_from_stream(*$1);
++    SPAGAIN;
++    %append_output(tmp);
+ }
+ #endif
+ 
+@@ -1116,7 +1125,11 @@ svn_ ## TYPE ## _swig_rb_closed(VALUE self)
+ }
+ 
+ %typemap(argout) unsigned char *result_digest {
+-    %append_output(svn_swig_pl_from_md5($1));
++    SV *tmp;
++    PUTBACK;
++    tmp = svn_swig_pl_from_md5($1);
++    SPAGAIN;
++    %append_output(tmp);
+ }
+ #endif
+ 
+-- 
+2.8.2
+

--- a/subversion/PKGBUILD
+++ b/subversion/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=subversion
 pkgver=1.9.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A Modern Concurrent Version Control System"
 arch=('i686' 'x86_64')
 url="https://subversion.apache.org/"
@@ -37,6 +37,7 @@ source=(https://archive.apache.org/dist/subversion/subversion-${pkgver}.tar.bz2{
         17-fix-test-link.patch
         18-fix-serf-config.patch
         19-remove-contrib-from-configure.patch
+        20-fix-stack-corruption-in-swig-wrappers.patch
         subversion-1.9.1-msys2.patch
         remove-checking-symlink.patch
         90-use-copy-instead-symlink.patch)
@@ -62,6 +63,7 @@ sha256sums=('1267f9e2ab983f260623bee841e6c9cc458bf4bf776238ed5f100983f79e9299'
             'f32780635df14f6c954d70ed7ff470ffe84edd314c881492cb811252644cae5a'
             'dcec738bb21ebf640522ef36fec4a83c7a26c93090df2df857e3f2825b597954'
             '7bfd5bceb6141d677806222dea4969231d0dfb9da765512672f0666649b9c885'
+            '8e7f949aa31ff46d2c786a41da18cf0f487dcf61c577a8984596e53186b77272'
             'f3d2e7e6ca97c8310fb59ce82430005fcd9e508b4a2a3f4ec7208011bf32a0a8'
             'e6e726b0121a9a2d3ce3942791478135728c13427851f5062554a8540109d634'
             '5268b1136d93691df238e0cc8b7d88739931d64779fc4528b65519f7e19b2dd2')
@@ -101,6 +103,7 @@ prepare() {
   patch -p1 -i ${srcdir}/17-fix-test-link.patch
   patch -p1 -i ${srcdir}/18-fix-serf-config.patch
   patch -p1 -i ${srcdir}/19-remove-contrib-from-configure.patch
+  patch -p1 -i ${srcdir}/20-fix-stack-corruption-in-swig-wrappers.patch
   patch -p1 -i ${srcdir}/subversion-1.9.1-msys2.patch
   patch -p1 -i ${srcdir}/remove-checking-symlink.patch
   patch -p1 -i ${srcdir}/90-use-copy-instead-symlink.patch


### PR DESCRIPTION
Subversion's script bindings (which are used in git-svn) can cause
segmentation faults simply by corrupting the stack under memory
pressure.

This bug was already fixed in Subversion's trunk, but that fix did not
make it into Subversion 1.9.4. Let's forward-port that patch manually.

See http://article.gmane.org/gmane.comp.version-control.git/298427 for
full details.

Reported by Ioannis Kappas.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>