### PR TITLE
CI: Use --needed when installing pactoys.

### DIFF
--- a/ci-library.sh
+++ b/ci-library.sh
@@ -134,7 +134,7 @@ update_system() {
     repman add ci.msys 'https://dl.bintray.com/alexpux/msys2' || return 1
     pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade --sysupgrade || return 1
     test -n "${DISABLE_QUALITY_CHECK}" && return 0 # TODO: remove this option when not anymore needed
-    pacman --noconfirm --noprogressbar --sync ci.msys/pactoys
+    pacman --noconfirm --needed --noprogressbar --sync ci.msys/pactoys
 }
 
 # Sort packages by dependency


### PR DESCRIPTION
Fix the below error demo by https://tea-ci.org/fracting/MSYS2-packages/117:

```
warning: pactoys-git-r2.07ca37f-1 is up to date -- reinstalling
resolving dependencies...
looking for conflicting packages...

Packages (1) pactoys-git-r2.07ca37f-1

Total Installed Size:  0.09 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] 
checking keyring...
checking package integrity...
:: File /var/cache/pacman/pkg/pactoys-git-r2.07ca37f-1-x86_64.pkg.tar.xz is corrupted (invalid or corrupted package (checksum)).
Do you want to delete it? [Y/n] 
error: failed to commit transaction (invalid or corrupted package (checksum))
Errors occurred, no packages were upgraded.

[MSYS2 CI] FAILURE: Updating system failed.
```