### PR TITLE
bashrc: re-include $PS1 priority

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=filesystem
 pkgver=2016.06
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -49,7 +49,7 @@ source=('bash.bash_logout'
         'mingw32-config.site'
         'redirect-config.site')
 sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
-            'b985a05176a940bfd46c33ac1a1f78b3b09508d8b7c28f8e23e542975e09e0e2'
+            '82fb61ad0e5625fe29d4fd2ef4d191cb76b24be17967076a45ba9941f855eb48'
             '99eae6e37081edd73b399009c85f4a67a0c14481241ee4937ab45c4178b540fb'
             'ed08a8bd0919ba29ec5dd2d0c74ba74324ca2bcbf7852354b0b6c523809029a0'
             '4330edf340394d0dae50afb04ac2a621f106fe67fb634ec81c4bfb98be2a1eb5'

--- a/filesystem/bash.bashrc
+++ b/filesystem/bash.bashrc
@@ -39,11 +39,14 @@ unset _warning_prefix
 unset _warning_file
 unset _warning
 
-# If MSYS2_PS1 is set, use that as default PS1, otherwise set a default prompt
+# If MSYS2_PS1 is set, use that as default PS1;
+# if a PS1 is already set, use that;
+# otherwise set a default prompt
 # of user@host, MSYSTEM variable, and current_directory
 if test -n "${MSYS2_PS1}"
     then PS1="${MSYS2_PS1}"
-    else PS1='\[\e]0;\w\a\]\n\[\e[32m\]\u@\h \[\e[35m\]$MSYSTEM\[\e[0m\] \[\e[33m\]\w\[\e[0m\]\n\$ '
+    elif test -z "${PS1}"
+        then PS1='\[\e]0;\w\a\]\n\[\e[32m\]\u@\h \[\e[35m\]$MSYSTEM\[\e[0m\] \[\e[33m\]\w\[\e[0m\]\n\$ '
 fi
 
 # Uncomment to use the terminal colours set in DIR_COLORS


### PR DESCRIPTION
6e6310d (filesystem: New specific variable MSYS2_PS1., 2016-05-01)
introduced the MSYS2_PS1 prompt script proriority to allow multiple
device configurations.

Unfortunately it overwrote the $PS1, even when specifically set by the
users configuration, such as the Git-for-Windows SDK
see https://github.com/git-for-windows/git/issues/794#issuecomment-227401839
and the monkey patch fix
https://github.com/git-for-windows/build-extra/pull/122.

Introduce a priority order so that the user's $PS1 (if set) has an
intermediate priority between the MSYS2_PS1 and the default PS1.

Signed-off-by: Philip Oakley <philipoakley@iee.org>