### PR TITLE
bash.bashrc: Update PS1 if PS1 wasn't exported.

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: Karlson2k (Evgeny Grin) <k2k@narod.ru>
 
 pkgname=filesystem
-pkgver=2016.06
-pkgrel=2
+pkgver=2016.07
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -49,7 +49,7 @@ source=('bash.bash_logout'
         'mingw32-config.site'
         'redirect-config.site')
 sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
-            '82fb61ad0e5625fe29d4fd2ef4d191cb76b24be17967076a45ba9941f855eb48'
+            '81706dc0674d06ddd98b630774816810e7dc25c1441e9805a4b6b81e1beaf3f1'
             '99eae6e37081edd73b399009c85f4a67a0c14481241ee4937ab45c4178b540fb'
             'ed08a8bd0919ba29ec5dd2d0c74ba74324ca2bcbf7852354b0b6c523809029a0'
             '4330edf340394d0dae50afb04ac2a621f106fe67fb634ec81c4bfb98be2a1eb5'

--- a/filesystem/bash.bashrc
+++ b/filesystem/bash.bashrc
@@ -40,14 +40,13 @@ unset _warning_file
 unset _warning
 
 # If MSYS2_PS1 is set, use that as default PS1;
-# if a PS1 is already set, use that;
+# if a PS1 is already set and exported, use that;
 # otherwise set a default prompt
 # of user@host, MSYSTEM variable, and current_directory
-if test -n "${MSYS2_PS1}"
-    then PS1="${MSYS2_PS1}"
-    elif test -z "${PS1}"
-        then PS1='\[\e]0;\w\a\]\n\[\e[32m\]\u@\h \[\e[35m\]$MSYSTEM\[\e[0m\] \[\e[33m\]\w\[\e[0m\]\n\$ '
-fi
+[[ -n "${MSYS2_PS1}" ]] && export PS1="${MSYS2_PS1}"
+[[ $(declare -p PS1 2>/dev/null | cut -c 1-11) = 'declare -x ' ]] || \
+  export PS1='\[\e]0;\w\a\]\n\[\e[32m\]\u@\h \[\e[35m\]$MSYSTEM\[\e[0m\] \[\e[33m\]\w\[\e[0m\]\n\$ '
+
 
 # Uncomment to use the terminal colours set in DIR_COLORS
 # eval "$(dircolors -b /etc/DIR_COLORS)"


### PR DESCRIPTION
Should fix regression introduced by #651

bash use some default value for PS1, but this value is not exported. This allow us to distinguish between user-defined PS1 and bash automatic default PS1.