### PR TITLE
msys2_shell.cmd updates and fixes

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=filesystem
 pkgver=2016.07
-pkgrel=1
+pkgrel=2
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -59,7 +59,7 @@ sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
             '50c3746d621e682e3560e1b37cc1ac5d988460064a20ed15f107c203ac5ad622'
             '9620bdf1c82ea3f14c3553c44a2006ea61ff3f5a775a2a053130a59cc186daf5'
             '7d6994d7caf52a459b562cfb0da1d758a4b7bca478d1df00de3a96686e59008e'
-            '45bdfd620e81e6c0ff0bc0e7d9fa1bc4efebe7382c37e8affc29e306fe3fe7b7'
+            'db22c5b21b1ee38ff978557754b59f3847f69d63f03d60cb664de4a816793810'
             '3c1da9bf6ff791c32f17e49db0047b3c9cbaacd44d6d0b92696cdeacebf8f947'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
             '24f4cd302d495d286134be5bd2466a1bef19c70e7ed825d0b61e49adcf3ad664'

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -17,11 +17,7 @@ rem set MSYS2_PATH_TYPE=inherit
 :checkparams
 rem Help option
 if "x%~1" == "x-help" (
-  echo Options:
-  echo     -mingw32,mingw64,msys            Set shell type
-  echo     -defterm,mintty,conemu,consolez  Set terminal type
-  echo     -here [DIRECTORY]                Starting directory
-  echo     -full-path                       Inherit Windows path
+  call :printhelp "%~nx0"
   exit /b 1
 )
 rem Shell types
@@ -123,4 +119,21 @@ if not defined ComEmuCommand (
   )
 )
 if not defined ComEmuCommand exit /b 2
+exit /b 0
+
+:printhelp
+echo Usage:
+echo     %~1 [options] [bash parameters]
+echo.
+echo Options:
+echo     -mingw32 ^| -mingw64 ^| -msys[2]   Set shell type
+echo     -defterm ^| -mintty ^| -conemu ^| -consolez
+echo                                      Set terminal type
+echo     -here [DIRECTORY]                Starting directory
+echo     -[use-]full-path                 Use full currnent PATH variable
+echo                                      instead of triming to minimal
+echo.
+echo Any parameter that cannot be treated as valid option and all
+echo following parameters are passed as bash command parameters.
+echo.
 exit /b 0

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -64,7 +64,7 @@ exit /b %ERRORLEVEL%
 
 :startconsolez
 cd %WD%..\lib\ConsoleZ
-start console -t "%CONTITLE%" -r %1 %2 %3 %4 %5 %6 %7 %8 %9
+start "%CONTITLE%" console -t "%CONTITLE%" -r %1 %2 %3 %4 %5 %6 %7 %8 %9
 exit /b %ERRORLEVEL%
 
 :startconemu

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -47,8 +47,17 @@ rem Other parameters
 if "x%~1" == "x-full-path" shift& set MSYS2_PATH_TYPE=inherit& goto :checkparams
 if "x%~1" == "x-use-full-path" shift& set MSYS2_PATH_TYPE=inherit& goto :checkparams
 if "x%~1" == "x-here" shift& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
-if "x%~1" == "x-where" shift& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
-if "x%CHERE_INVOKING%" == "xenabled_from_arguments" if not "%~1" == "" if exist "%~1\" shift& cd /d "%~1\"& goto :checkparams
+if "x%~1" == "x-where" (
+  if "x%~2" == "x" (
+    echo Working directory is not specified for -where parameter. 1>&2
+    exit /b 2
+  )
+  cd /d "%~2" || (
+    echo Cannot set specified working diretory "%~2". 1>&2
+    exit /b 2
+  )
+  set CHERE_INVOKING=enabled_from_arguments
+)& shift& shift& goto :checkparams
 
 rem Setup proper title
 if "%MSYSTEM%" == "MINGW32" (
@@ -141,7 +150,10 @@ echo Options:
 echo     -mingw32 ^| -mingw64 ^| -msys[2]   Set shell type
 echo     -defterm ^| -mintty ^| -conemu ^| -consolez
 echo                                      Set terminal type
-echo     -here [DIRECTORY]                Starting directory
+echo     -here                            Use current directory as working
+echo                                      directory
+echo     -where DIRECTORY                 Use specified DIRECTORY as working
+echo                                      directory
 echo     -[use-]full-path                 Use full currnent PATH variable
 echo                                      instead of triming to minimal
 echo     -help ^| --help ^| -? ^| /?         Display this help and exit

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -20,6 +20,18 @@ if "x%~1" == "x-help" (
   call :printhelp "%~nx0"
   exit /b %ERRORLEVEL%
 )
+if "x%~1" == "x--help" (
+  call :printhelp "%~nx0"
+  exit /b %ERRORLEVEL%
+)
+if "x%~1" == "x-?" (
+  call :printhelp "%~nx0"
+  exit /b %ERRORLEVEL%
+)
+if "x%~1" == "x/?" (
+  call :printhelp "%~nx0"
+  exit /b %ERRORLEVEL%
+)
 rem Shell types
 if "x%~1" == "x-msys" shift& set MSYSTEM=MSYS& goto :checkparams
 if "x%~1" == "x-msys2" shift& set MSYSTEM=MSYS& goto :checkparams
@@ -132,6 +144,7 @@ echo                                      Set terminal type
 echo     -here [DIRECTORY]                Starting directory
 echo     -[use-]full-path                 Use full currnent PATH variable
 echo                                      instead of triming to minimal
+echo     -help ^| --help ^| -? ^| /?         Display this help and exit
 echo.
 echo Any parameter that cannot be treated as valid option and all
 echo following parameters are passed as bash command parameters.

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -18,7 +18,7 @@ rem set MSYS2_PATH_TYPE=inherit
 rem Help option
 if "x%~1" == "x-help" (
   call :printhelp "%~nx0"
-  exit /b 1
+  exit /b %ERRORLEVEL%
 )
 rem Shell types
 if "x%~1" == "x-msys" shift& set MSYSTEM=MSYS& goto :checkparams

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -72,7 +72,7 @@ call :conemudetect || (
   echo ConEmu not found. Exiting. 1>&2
   exit /b 1
 )
-start "%CONTITLE%" "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd %WD%bash --login %1 %2 %3 %4 %5 %6 %7 %8 %9
+start "%CONTITLE%" "%ComEmuCommand%" /Here /Icon "%WD%..\..\msys2.ico" /cmd "%WD%bash" --login %1 %2 %3 %4 %5 %6 %7 %8 %9
 exit /b %ERRORLEVEL%
 
 :startsh

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -26,10 +26,10 @@ if "x%~1" == "x-help" (
 )
 rem Shell types
 if "x%~1" == "x-msys" shift& set MSYSTEM=MSYS& goto :checkparams
-if "x%~1" == "x-msys2" shift& set MSYSTEM=MSYS& set _deprecated_msys2=true& goto :checkparams
+if "x%~1" == "x-msys2" shift& set MSYSTEM=MSYS& goto :checkparams
 if "x%~1" == "x-mingw32" shift& set MSYSTEM=MINGW32& goto :checkparams
 if "x%~1" == "x-mingw64" shift& set MSYSTEM=MINGW64& goto :checkparams
-if "x%~1" == "x-mingw" shift& set _deprecated_mingw=true& (if exist "%WD%..\..\mingw64" (set MSYSTEM=MINGW64) else (set MSYSTEM=MINGW32))& goto :checkparams
+if "x%~1" == "x-mingw" shift& (if exist "%WD%..\..\mingw64" (set MSYSTEM=MINGW64) else (set MSYSTEM=MINGW32))& goto :checkparams
 rem Console types
 if "x%~1" == "x-consolez" shift& set MSYSCON=console.exe& goto :checkparams
 if "x%~1" == "x-mintty" shift& set MSYSCON=mintty.exe& goto :checkparams
@@ -37,29 +37,10 @@ if "x%~1" == "x-conemu" shift& set MSYSCON=conemu& goto :checkparams
 if "x%~1" == "x-defterm" shift& set MSYSCON=defterm& goto :checkparams
 rem Other parameters
 if "x%~1" == "x-full-path" shift& set MSYS2_PATH_TYPE=inherit& goto :checkparams
-if "x%~1" == "x-use-full-path" shift& set MSYS2_PATH_TYPE=inherit& set _deprecated_use_full_path=true& goto :checkparams
+if "x%~1" == "x-use-full-path" shift& set MSYS2_PATH_TYPE=inherit& goto :checkparams
 if "x%~1" == "x-here" shift& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
-if "x%~1" == "x-where" shift& set CHERE_INVOKING=enabled_from_arguments& set _deprecated_where=true& goto :checkparams
+if "x%~1" == "x-where" shift& set CHERE_INVOKING=enabled_from_arguments& goto :checkparams
 if "x%CHERE_INVOKING%" == "xenabled_from_arguments" if not "%~1" == "" if exist "%~1\" shift& cd /d "%~1\"& goto :checkparams
-
-rem Deprecated parameters
-rem TODO: remove this check when most users have stopped using them
-if "x%_deprecated_use_full_path%" == "xtrue" (
-  echo The MSYS2 shell has been started with the deprecated -use-full-path> "%WD%..\..\etc\profile.d\msys2_shell.use_full_path.warning.once"
-  echo option. Please update your shortcuts to use -full-path instead.>>    "%WD%..\..\etc\profile.d\msys2_shell.use_full_path.warning.once"
-)
-if "x%_deprecated_where%" == "xtrue" (
-  echo The MSYS2 shell has been started with the deprecated -where> "%WD%..\..\etc\profile.d\msys2_shell.where.warning.once"
-  echo option. Please update your shortcuts to use -here instead.>> "%WD%..\..\etc\profile.d\msys2_shell.where.warning.once"
-)
-if "x%_deprecated_msys2%" == "xtrue" (
-  echo The MSYS2 shell has been started with the deprecated -msys2> "%WD%..\..\etc\profile.d\msys2_shell.msys2.warning.once"
-  echo option. Please update your shortcuts to use -msys instead.>> "%WD%..\..\etc\profile.d\msys2_shell.msys2.warning.once"
-)
-if "x%_deprecated_mingw%" == "xtrue" (
-  echo The MSYS2 shell has been started with the deprecated -mingw option.> "%WD%..\..\etc\profile.d\msys2_shell.mingw.warning.once"
-  echo Please update your shortcuts to use -mingw32 or -mingw64 instead.>>  "%WD%..\..\etc\profile.d\msys2_shell.mingw.warning.once"
-)
 
 rem Setup proper title
 if "%MSYSTEM%" == "MINGW32" (


### PR DESCRIPTION
Currently msys2_shell.cmd has several issues:
* You cannot pass parameter to shell, if you have directory with the same name. For example, command `msys2_shell.cmd -here -c 'bash -c ls; sleep 5'` will not work if you have directory named `-c`.
* You cannot use directory names like '-help', '-mingw64' and so on - they will be interpreted as parameters. Moreover, last parameter will be used as directory name. For example command `msys2_shell.cmd -mingw64 -here -msys -defterm scripts` will launch **MSys** shell instead of **MinGW64** shell in directory **`scripts`** instead of directory **`-msys`** (even if `-msys` directory is present).
* If you mistyped name of working directory, it will be silently passed as bash parameter. For example `msys2_shell.cmd -mingw64 -here my_driectory` will pass `my_driectory` as bash parameter.

If you try to use `-where` instead of `-here`, result will be exactly the same.

This update will fix those issues and remove ambiguous meaning of `-here` parameter: now `-here` means current directory and `-where` means specified directory. If specified directory doesn't exist, error will be displayed and error status returned by script.

This update also remove deprecation warnings - let users use parameters which are convenient for them.
Additionally, help message is clarified and some minor fixes and improvements are included.