### PR TITLE
msys2-launcher-git: correct mintty epoch value

### DIFF
--- a/msys2-launcher-git/PKGBUILD
+++ b/msys2-launcher-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname="msys2-launcher"
 pkgname=("${_realname}-git")
 pkgver=0.3.32.56c2ba7
-pkgrel=1
+pkgrel=2
 pkgdesc="Helper for launching MSYS2 shells"
 arch=('x86_64' 'i686')
 license=('MIT')
@@ -11,7 +11,7 @@ groups=('base')
 backup=({mingw32,mingw64,msys2}.ini)
 provides=("${_realname}")
 conflicts=("${_realname}")
-depends=("mintty>=2.2.1")
+depends=("mintty>=1~2.2.1")
 makedepends=('mingw-w64-cross-gcc')
 source=("git+https://github.com/elieux/msys2-launcher")
 sha256sums=('SKIP')


### PR DESCRIPTION
Use correct epoch when specifying mintty dependency:
mintty package started using an epoch value since version 1~2.0.3 (92fcd06).