### PR TITLE
gyp-git: update and fix too long filenames

### DIFF
--- a/gyp-git/PKGBUILD
+++ b/gyp-git/PKGBUILD
@@ -3,7 +3,7 @@
 
 _realname=gyp
 pkgname=${_realname}-git
-pkgver=r2051.2b08654
+pkgver=r2097.eeb0738
 pkgrel=1
 pkgdesc="GYP can Generate Your Projects."
 url="https://code.google.com/p/gyp/"
@@ -15,9 +15,11 @@ makedepends=('git')
 depends=('python2' 'python2-setuptools')
 license=('custom')
 source=("git+https://chromium.googlesource.com/external/gyp"
-        '0001-msys-ize.patch')
+        '0001-msys-ize.patch'
+        'issue2019133002_1.diff')
 sha256sums=('SKIP'
-            '5e402b570bfeb8c95fec6ddd55afbe316d9bb4b04090c8f09cff6664bd00297e')
+            '5e402b570bfeb8c95fec6ddd55afbe316d9bb4b04090c8f09cff6664bd00297e'
+            '39732ad06e88f2195acc348231dc93eb20aa5fbffbe05ffef5c29344f9a264ec')
 
 pkgver() {
   cd "${srcdir}"/${_realname}
@@ -27,6 +29,9 @@ pkgver() {
 prepare() {
   cd "${srcdir}"/${_realname}
   git am "${srcdir}"/0001-msys-ize.patch
+  
+  #https://codereview.chromium.org/2019133002/
+  patch -p1 -i "${srcdir}"/issue2019133002_1.diff
 }
 
 package() {

--- a/gyp-git/issue2019133002_1.diff
+++ b/gyp-git/issue2019133002_1.diff
@@ -1,0 +1,35 @@
+Index: pylib/gyp/generator/make.py
+diff --git a/pylib/gyp/generator/make.py b/pylib/gyp/generator/make.py
+index b7da768fb33f5a8e12ec6ffa4c20e2fc6c1434e8..d5b200ad553369daa48b767582ce510fa4a78229 100644
+--- a/pylib/gyp/generator/make.py
++++ b/pylib/gyp/generator/make.py
+@@ -31,6 +31,17 @@ import gyp.xcode_emulation
+ from gyp.common import GetEnvironFallback
+ from gyp.common import GypError
+ 
++# hashlib is supplied as of Python 2.5 as the replacement interface for sha
++# and other secure hashes.  In 2.6, sha is deprecated.  Import hashlib if
++# available, avoiding a deprecation warning under 2.6.  Import sha otherwise,
++# preserving 2.4 compatibility.
++try:
++  import hashlib
++  _new_sha1 = hashlib.sha1
++except ImportError:
++  import sha
++  _new_sha1 = sha.new
++
+ generator_default_variables = {
+   'EXECUTABLE_PREFIX': '',
+   'EXECUTABLE_SUFFIX': '',
+@@ -1743,7 +1754,10 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
+       #   actual command.
+       # - The intermediate recipe will 'touch' the intermediate file.
+       # - The multi-output rule will have an do-nothing recipe.
+-      intermediate = "%s.intermediate" % (command if command else self.target)
++
++      # Hash the target name to avoid generating overlong filenames.
++      cmddigest = _new_sha1(command if command else self.target).hexdigest()
++      intermediate = "%s.intermediate" % (cmddigest)
+       self.WriteLn('%s: %s' % (' '.join(outputs), intermediate))
+       self.WriteLn('\t%s' % '@:');
+       self.WriteLn('%s: %s' % ('.INTERMEDIATE', intermediate))


### PR DESCRIPTION
Should fix many cases of `/bin/sh: /mingw64/bin/ar: Argument list too long` when buidling some gyp projects on Windows.