### PR TITLE
openssh: allow scp to copy files using their Windows paths.

### DIFF
--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=openssh
 pkgver=7.3p1
-pkgrel=1
+pkgrel=2
 pkgdesc='Free version of the SSH connectivity tools'
 url='http://www.openssh.org/portable.html'
 license=('custom:BSD')
@@ -13,11 +13,13 @@ makedepends=('heimdal-devel' 'libedit-devel' 'libcrypt-devel' 'openssl-devel')
 source=("http://mirrors.mit.edu/pub/OpenBSD/OpenSSH/portable/${pkgname}-${pkgver}.tar.gz"
         openssh-7.3p1-msys2.patch
         openssh-7.3p1-msys2-setkey.patch
-        openssh-7.3p1-msys2-skip-privsep-tests.patch)
+        openssh-7.3p1-msys2-skip-privsep-tests.patch
+        openssh-7.3p1-msys2-drive-name-in-path.patch)
 sha256sums=('3ffb989a6dcaa69594c3b550d4855a5a2e1718ccdde7f5e36387b424220fbecc'
             'ab54293758c908bfdcd95b338bad5eb35290291e957dc99bc09fae4f906987fc'
             '25079cf4a10c1ab70d60302bccaabee513762520dffd7c35285f7aae3ea36087'
-            '729aa8ef3723a223afbd1bda678a7deaca75b5c3b42a74b1a8c396f95f8677b5')
+            '729aa8ef3723a223afbd1bda678a7deaca75b5c3b42a74b1a8c396f95f8677b5'
+            '903b3eee51e492a125cab9c724ad967450307d53e457f025e4432b81cb145af5')
 
 backup=('etc/ssh/ssh_config')
 
@@ -26,6 +28,7 @@ prepare() {
   patch -p1 -i ${srcdir}/openssh-7.3p1-msys2.patch
   patch -p1 -i ${srcdir}/openssh-7.3p1-msys2-setkey.patch
   patch -p1 -i ${srcdir}/openssh-7.3p1-msys2-skip-privsep-tests.patch
+  patch -p1 -i ${srcdir}/openssh-7.3p1-msys2-drive-name-in-path.patch
   autoreconf -fvi
 }
 

--- a/openssh/openssh-7.3p1-msys2-drive-name-in-path.patch
+++ b/openssh/openssh-7.3p1-msys2-drive-name-in-path.patch
@@ -1,0 +1,56 @@
+From 0e80940f9ea248f519e23893d0e66079d9ee5f31 Mon Sep 17 00:00:00 2001
+From: Sam Hocevar <sam@hocevar.net>
+Date: Tue, 20 Sep 2016 10:34:18 +0200
+Subject: [PATCH] Allow scp to copy files that start with a Windows drive name.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On Windows, “scp C:/foo/bar remotehost:” will attempt to connect to
+a remote host “C” and access file “/foo/bar”. There is currently no
+syntax or flag to allow copying files that start with a drive name.
+
+This patch changes the behaviour (only on Cygwin) by considering
+that a single letter followed by a colon is a Windows drive name
+and thus an absolute path. This is also more consistent with the
+manual page that recommends to use absolute pathnames “to avoid
+scp treating file names containing ‘:’ as host specifiers.
+
+It is still possible to access files on a machine “C” by using
+square brackets, e.g. “scp [C]:/foo/bar remotehost:”.
+
+There are countless user reports indicating that this behaviour
+is desirable:
+ - http://stackoverflow.com/q/8975798/111461
+ - http://serverfault.com/q/582048/73723
+ - http://superuser.com/q/291840/71253
+ - https://www.reddit.com/r/commandline/comments/371q5i
+ - http://stackoverflow.com/q/21587036/111461
+ - http://askubuntu.com/q/354330/12301
+ - http://superuser.com/q/338075/71253
+ - https://ubuntuforums.org/archive/index.php/t-1131655.html
+ - http://www.linuxquestions.org/questions/linux-newbie-8/transfer-files-from-linux-to-windows-pscp-4175530524/
+
+Signed-off-by: Sam Hocevar <sam@hocevar.net>
+---
+ misc.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/misc.c b/misc.c
+index 9421b4d..cd10287 100644
+--- a/misc.c
++++ b/misc.c
+@@ -435,6 +435,10 @@ colon(char *cp)
+ 
+ 	if (*cp == ':')		/* Leading colon is part of file name. */
+ 		return NULL;
++#ifdef HAVE_CYGWIN
++	if (isalpha(*cp) && *(cp+1) == ':')	/* Do not split at drive name. */
++		return NULL;
++#endif
+ 	if (*cp == '[')
+ 		flag = 1;
+ 
+-- 
+2.9.3
+


### PR DESCRIPTION
This patch was also proposed to upstream developers:
 http://lists.mindrot.org/pipermail/openssh-unix-dev/2016-September/035381.html