### PR TITLE
Upgrade openssl to 1.0.2j

### DIFF
--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=('openssl' 'libopenssl' 'openssl-devel')
-_ver=1.0.2h
+_ver=1.0.2j
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=1
@@ -19,7 +19,7 @@ source=("https://www.openssl.org/source/${pkgname}-${_ver}.tar.gz"{,.asc}
         'openssl-1.0.1e-cygwin64.patch'
         'openssl-1.0.1e-msys2.patch'
         'openssl-1.0.0-beta5-enginesdir.patch')
-sha256sums=('1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919'
+sha256sums=('e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431'
             'SKIP'
             '754d6107a306311e15a1db6a1cc031b81691c8b9865e8809ac60ca6f184c957c'
             '01b7d475d1aeeecdae1ca8ff90483c11f34991348418d9e98c655e1579764bb1'


### PR DESCRIPTION
... including a security fix.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>