### PR TITLE
libarchive - 3.2.2 Update to latest version

### DIFF
--- a/libarchive/PKGBUILD
+++ b/libarchive/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=('libarchive' 'libarchive-devel' 'bsdcpio' 'bsdtar')
-pkgver=3.2.1
+pkgver=3.2.2
 pkgrel=1
 pkgdesc="library that can create and read several streaming archive formats"
 arch=('i686' 'x86_64')
@@ -13,16 +13,19 @@ makedepends=('libbz2-devel' 'libiconv-devel' 'liblzma-devel' 'liblzo2-devel' 'li
 options=('!strip' 'debug' 'libtool')
 # provides=('libarchive.so')
 source=("http://libarchive.org/downloads/$pkgname-$pkgver.tar.gz"
-        'libarchive-3.2.0-msys2.patch')
-sha256sums=('72ee1a4e3fd534525f13a0ba1aa7b05b203d186e0c6072a8a4738649d0b3cfd2'
-            '639f316243509470c6f8132e59104a49bfb8df61be9722887d145a1b7262286c')
+        'libarchive-3.2.0-msys2.patch'
+        'libarchive-3.2.2-path_fix.patch')
+sha256sums=('691c194ee132d1f0f7a42541f091db811bc2e56f7107e9121be2bc8c04f1060f'
+            '639f316243509470c6f8132e59104a49bfb8df61be9722887d145a1b7262286c'
+            '5c80ad55e47decd47330af6fb6e4237ef024b9053582b4ac9c6dcd2b4b341a43')
 
 prepare() {
   cd "$pkgname-$pkgver"
 
   # msysize patch
   patch -Np1 -i "$srcdir/libarchive-3.2.0-msys2.patch"
-
+  # fix breakage with an internal routine "cleanup_pathname_win"
+  patch -Np1 -i "$srcdir/libarchive-3.2.2-path_fix.patch"
   autoreconf -ivf
 }
 

--- a/libarchive/libarchive-3.2.2-path_fix.patch
+++ b/libarchive/libarchive-3.2.2-path_fix.patch
@@ -1,0 +1,38 @@
+--- libarchive-3.2.2/libarchive/archive_write_disk_posix.c.orig	2016-11-01 00:12:25.688260500 -0400
++++ libarchive-3.2.2/libarchive/archive_write_disk_posix.c	2016-11-01 00:17:05.439478200 -0400
+@@ -2625,7 +2625,7 @@
+  * See also : http://msdn.microsoft.com/en-us/library/aa365247.aspx
+  */
+ static void
+-cleanup_pathname_win(struct archive_write_disk *a)
++cleanup_pathname_win(char *path)
+ {
+ 	wchar_t wc;
+ 	char *p;
+@@ -2636,7 +2636,7 @@
+ 	mb = 0;
+ 	complete = 1;
+ 	utf8 = (strcmp(nl_langinfo(CODESET), "UTF-8") == 0)? 1: 0;
+-	for (p = a->name; *p != '\0'; p++) {
++	for (p = path; *p != '\0'; p++) {
+ 		++alen;
+ 		if (*p == '\\') {
+ 			/* If previous byte is smaller than 128,
+@@ -2661,7 +2661,7 @@
+ 	/*
+ 	 * Convert path separator in wide-character.
+ 	 */
+-	p = a->name;
++	p = path;
+ 	while (*p != '\0' && alen) {
+ 		l = mbtowc(&wc, p, alen);
+ 		if (l == (size_t)-1) {
+@@ -2703,7 +2703,7 @@
+ 	}
+ 
+ #if defined(__CYGWIN__)
+-	cleanup_pathname_win(a);
++	cleanup_pathname_win(path);
+ #endif
+ 	/* Skip leading '/'. */
+ 	if (*src == '/') {


### PR DESCRIPTION
Latest version
Add patch for a compiler error.  I have taken the liberty of making a
merge request to the libarchive developers.
https://github.com/libarchive/libarchive/pull/818 .  I deally, I would
like to remove all patches from this.