### PR TITLE
curl: upgrade to v7.51.0

### DIFF
--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgbase=curl
 pkgname=('curl' 'libcurl' 'libcurl-devel')
-pkgver=7.50.3
+pkgver=7.51.0
 pkgrel=1
 pkgdesc="Multi-protocol file transfer utility"
 arch=('i686' 'x86_64')
@@ -13,7 +13,7 @@ makedepends=('heimdal-devel' 'libmetalink-devel' 'libcrypt-devel' 'libidn-devel'
 options=('!libtool' 'strip' '!debug')
 source=("https://curl.haxx.se/download/${pkgname}-${pkgver}.tar.bz2"{,.asc}
         curl-7.32.0-msys2.patch)
-sha256sums=('7b7347d976661d02c84a1f4d6daf40dee377efdc45b9e2c77dedb8acf140d8ec'
+sha256sums=('7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde'
             'SKIP'
             '703963690bfa95b92e8281b7d9070a12c18bada044c3a7c9995fe9ae5adc5a8f')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg


### PR DESCRIPTION
This version closes 11 critical bugs, along with other bugs.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>