### PR TITLE
rtorrent: New package 0.9.6

### DIFF
--- a/libtorrent/01-fix_libraries.patch
+++ b/libtorrent/01-fix_libraries.patch
@@ -1,0 +1,22 @@
+diff -ruN libtorrent-0.13.6-orig/libtorrent.pc.in libtorrent-0.13.6/libtorrent.pc.in
+--- libtorrent-0.13.6-orig/libtorrent.pc.in	2015-09-03 18:30:55.000000000 +0000
++++ libtorrent-0.13.6/libtorrent.pc.in	2016-11-08 09:42:49.681229600 +0000
+@@ -6,5 +6,5 @@
+ Name: libtorrent
+ Description: A BitTorrent library
+ Version: @VERSION@
+-Libs: -L${libdir} -ltorrent
++Libs: -L${libdir} -ltorrent -lcrypto -lz
+ Cflags: -I${includedir}
+diff -ruN libtorrent-0.13.6-orig/src/Makefile.am libtorrent-0.13.6/src/Makefile.am
+--- libtorrent-0.13.6-orig/src/Makefile.am	2015-09-03 18:30:55.000000000 +0000
++++ libtorrent-0.13.6/src/Makefile.am	2016-11-08 09:35:05.411954700 +0000
+@@ -10,7 +10,7 @@
+ 
+ lib_LTLIBRARIES = libtorrent.la
+ 
+-libtorrent_la_LDFLAGS = -version-info $(LIBTORRENT_INTERFACE_VERSION_INFO)
++libtorrent_la_LDFLAGS = -version-info $(LIBTORRENT_INTERFACE_VERSION_INFO) -no-undefined
+ libtorrent_la_LIBADD = \
+ 	torrent/libsub_torrent.la \
+ 	torrent/data/libsub_torrentdata.la \

--- a/libtorrent/PKGBUILD
+++ b/libtorrent/PKGBUILD
@@ -1,0 +1,42 @@
+pkgname=libtorrent
+pkgver=0.13.6
+pkgrel=1
+pkgdesc='BitTorrent library with a focus on high performance and good code'
+url='http://rakshasa.github.io/rtorrent/'
+arch=('i686' 'x86_64')
+license=('GPL')
+depends=('openssl')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/rakshasa/${pkgname}/archive/${pkgver}.tar.gz" '01-fix_libraries.patch')
+sha256sums=('bf963ac6e73e194a2cd87ebdf809988b5b3d6244bb7cd43d7d0c4852fc501524' 'cf456e0d8dce0ce9f1c90c09ead5ce2faa2b79da3f8a564ffd197d214a4745aa')
+options=('strip' 'staticlibs')
+makedepends=(gcc pkg-config zlib)
+depends=(libcrypt-devel openssl-devel)
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  
+	cd "${srcdir}/${pkgname}-${pkgver}"
+	sed '/AM_PATH_CPPUNIT/d' -i configure.ac
+  patch -p1 -i ${srcdir}/01-fix_libraries.patch
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  ./autogen.sh
+
+  ./configure \
+    --build=${CHOST} \
+    --prefix=/usr \
+    --disable-mincore \
+    --disable-debug \
+    --enable-static
+  
+  make
+}
+
+package() {
+	cd "${srcdir}/${pkgname}-${pkgver}"
+	make \
+    DESTDIR="${pkgdir}" \
+    install
+}

--- a/rtorrent/01-fix_flags.patch
+++ b/rtorrent/01-fix_flags.patch
@@ -1,0 +1,21 @@
+--- rtorrent-0.9.6-orig/src/utils/directory.cc  2015-09-03 19:03:45.000000000 +0000
++++ rtorrent-0.9.6/src/utils/directory.cc       2016-11-07 16:38:18.298862400 +0000
+@@ -71,7 +71,7 @@
+     return false;
+
+   struct dirent* entry;
+-#ifdef __sun__
++#if defined(__sun__) || defined(__MSYS__)
+   struct stat s;
+ #endif
+
+@@ -81,7 +81,7 @@
+
+     iterator itr = base_type::insert(end(), value_type());
+
+-#ifdef __sun__
++#if defined(__sun__) || defined(__MSYS__)
+     stat(entry->d_name, &s);
+     itr->d_fileno = entry->d_ino;
+     itr->d_reclen = 0;
+

--- a/rtorrent/PKGBUILD
+++ b/rtorrent/PKGBUILD
@@ -1,0 +1,40 @@
+pkgname=(rtorrent)
+pkgver=0.9.6
+pkgrel=1
+groups=()
+pkgdesc='Ncurses BitTorrent client based on libTorrent'
+url='http://rakshasa.github.io/rtorrent/'
+license=('GPL')
+arch=('i686' 'x86_64')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/rakshasa/${pkgname}/archive/${pkgver}.tar.gz" '01-fix_flags.patch')
+sha256sums=('8ca89ca9e8f0cf984198d030203087e93d24743dfa158091a5d225a70ca4c8cf' 'SKIP')
+makedepends=(ncurses-devel libcurl-devel libcrypt-devel libiconv-devel libsqlite-devel libtorrent openssl-devel)
+depends=(ncurses curl)
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  sed '/AM_PATH_CPPUNIT/d' -i configure.ac
+  
+  patch -p1 -i ${srcdir}/01-fix_flags.patch
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  ./autogen.sh
+  ./configure \
+    --build=${CHOST} \
+    --prefix=/usr \
+    --disable-debug \
+    CXXFLAGS="${CPPFLAGS} -I/usr/include/ncursesw"
+    
+  make
+}
+
+package() {
+	cd "${srcdir}/${pkgname}-${pkgver}"  
+	make \
+    DESTDIR="${pkgdir}" \
+    install
+    
+  install -D doc/rtorrent.rc "${pkgdir}"/usr/share/doc/rtorrent/rtorrent.rc
+}


### PR DESCRIPTION
Added new package, inspired from https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/rtorrent. 