### PR TITLE
msys2-runtime: leave cygwin- pipe names as is

### DIFF
--- a/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
+++ b/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
@@ -1,12 +1,11 @@
-From b6e6cb27503d4cae9e7346dc1bbed2e5e9972d35 Mon Sep 17 00:00:00 2001
+From 7f48f1d02d00ad8613b78f1f3764b9588530161b Mon Sep 17 00:00:00 2001
 From: Alexpux <alexey.pawlow@gmail.com>
-Date: Tue, 5 Apr 2016 10:15:20 +0300
+Date: Mon, 14 Nov 2016 08:09:59 +0500
 Subject: [PATCH 02/23] Rename DLL from cygwin to msys
 
 ---
  winsup/Makefile.in                        |  4 +--
  winsup/cygserver/Makefile.in              |  6 ++---
- winsup/cygserver/transport_pipes.h        |  4 +++
  winsup/cygwin/Makefile.in                 | 38 ++++++++++++++-------------
  winsup/cygwin/common.din                  |  4 +--
  winsup/cygwin/configure                   |  4 +--
@@ -23,7 +22,6 @@ Subject: [PATCH 02/23] Rename DLL from cygwin to msys
  winsup/cygwin/dll_init.cc                 |  8 ++++++
  winsup/cygwin/dtable.cc                   |  6 +++++
  winsup/cygwin/exceptions.cc               |  4 +--
- winsup/cygwin/fhandler_tty.cc             | 12 +++++++++
  winsup/cygwin/fork.cc                     |  2 +-
  winsup/cygwin/hookapi.cc                  |  4 +++
  winsup/cygwin/i686.din                    |  6 ++---
@@ -35,7 +33,6 @@ Subject: [PATCH 02/23] Rename DLL from cygwin to msys
  winsup/cygwin/lib/cygwin_crt0.c           |  8 ++++++
  winsup/cygwin/mkvers.sh                   |  6 ++---
  winsup/cygwin/pinfo.cc                    |  4 +--
- winsup/cygwin/pipe.cc                     |  4 +++
  winsup/cygwin/pseudo-reloc.cc             |  2 +-
  winsup/cygwin/sec_auth.cc                 | 10 +++----
  winsup/cygwin/syscalls.cc                 |  4 +--
@@ -58,7 +55,7 @@ Subject: [PATCH 02/23] Rename DLL from cygwin to msys
  winsup/utils/path.cc                      | 12 ++++-----
  winsup/utils/ssp.c                        |  8 +++---
  winsup/utils/strace.cc                    | 10 +++----
- 54 files changed, 250 insertions(+), 137 deletions(-)
+ 51 files changed, 230 insertions(+), 137 deletions(-)
 
 diff --git a/winsup/Makefile.in b/winsup/Makefile.in
 index 148d985..81ce93c 100644
@@ -100,24 +97,8 @@ index 16a2ccc..b86d996 100644
  
  clean:
  	rm -f $(OBJS) ${patsubst %.o,%.d,$(OBJS)} cygserver.exe
-diff --git a/winsup/cygserver/transport_pipes.h b/winsup/cygserver/transport_pipes.h
-index e101623..66272bc 100644
---- a/winsup/cygserver/transport_pipes.h
-+++ b/winsup/cygserver/transport_pipes.h
-@@ -11,7 +11,11 @@ details. */
- #ifndef _TRANSPORT_PIPES_H
- #define _TRANSPORT_PIPES_H
- 
-+#ifdef __MSYS__
-+#define PIPE_NAME_PREFIX	L"\\\\.\\pipe\\msys-"
-+#else
- #define PIPE_NAME_PREFIX	L"\\\\.\\pipe\\cygwin-"
-+#endif
- #define PIPE_NAME_SUFFIX	L"-lpc"
- 
- /* Named pipes based transport, for security on NT */
 diff --git a/winsup/cygwin/Makefile.in b/winsup/cygwin/Makefile.in
-index 7c01df7..89b3452 100644
+index 70da06f..0c771a5 100644
 --- a/winsup/cygwin/Makefile.in
 +++ b/winsup/cygwin/Makefile.in
 @@ -106,17 +106,17 @@ RUNTEST = `if [ -f $${srcdir}/../dejagnu/runtest ] ; then \
@@ -153,7 +134,7 @@ index 7c01df7..89b3452 100644
  	--exclude='(?i:dll)' \
  	--exclude='reloc' \
  	--exclude='^main$$' \
-@@ -537,7 +538,7 @@ endif
+@@ -538,7 +539,7 @@ endif
  
  API_VER:=$(srcdir)/include/cygwin/version.h
  
@@ -162,7 +143,7 @@ index 7c01df7..89b3452 100644
  SUBLIBS:=libpthread.a libutil.a ${CURDIR}/libm.a ${CURDIR}/libc.a libdl.a libresolv.a librt.a libacl.a
  EXTRALIBS:=libautomode.a libbinmode.a libtextmode.a libtextreadmode.a
  INSTOBJS:=automode.o binmode.o textmode.o textreadmode.o
-@@ -587,7 +588,8 @@ install-libs: $(TARGET_LIBS)
+@@ -588,7 +589,8 @@ install-libs: $(TARGET_LIBS)
  	for i in $^; do \
  	    $(INSTALL_DATA) $$i $(DESTDIR)$(tooldir)/lib/`basename $$i` ; \
  	done
@@ -172,7 +153,7 @@ index 7c01df7..89b3452 100644
  
  install-headers:
  	cd $(srcdir); \
-@@ -652,7 +654,7 @@ uninstall-man:
+@@ -653,7 +655,7 @@ uninstall-man:
  	done
  
  clean distclean realclean:
@@ -181,7 +162,7 @@ index 7c01df7..89b3452 100644
  	-@$(MAKE) -C ${cygserver_blddir} libclean
  
  maintainer-clean: clean
-@@ -665,29 +667,29 @@ maintainer-clean: clean
+@@ -666,29 +668,29 @@ maintainer-clean: clean
  $(LDSCRIPT): $(LDSCRIPT).in
  	$(CC) -E - -P < $^ -o $@
  
@@ -220,10 +201,10 @@ index 7c01df7..89b3452 100644
  $(LIBSERVER): ${cygserver_blddir}/Makefile
  	$(MAKE) -C ${cygserver_blddir} libcygserver.a
 diff --git a/winsup/cygwin/common.din b/winsup/cygwin/common.din
-index b0064c8..6edd581 100644
+index 2ae3c81..db7ad78 100644
 --- a/winsup/cygwin/common.din
 +++ b/winsup/cygwin/common.din
-@@ -349,8 +349,8 @@ cygwin_attach_handle_to_fd SIGFE
+@@ -347,8 +347,8 @@ cygwin_attach_handle_to_fd SIGFE
  cygwin_conv_path SIGFE
  cygwin_conv_path_list SIGFE
  cygwin_create_path SIGFE
@@ -337,7 +318,7 @@ index fc1576b..b297511 100644
  #ifndef __INSIDE_CYGWIN__
  class transport_layer_base;
 diff --git a/winsup/cygwin/cygthread.cc b/winsup/cygwin/cygthread.cc
-index 4404e4a..db58586 100644
+index fc051cd..1aa3072 100644
 --- a/winsup/cygwin/cygthread.cc
 +++ b/winsup/cygwin/cygthread.cc
 @@ -168,7 +168,7 @@ new (size_t)
@@ -394,10 +375,10 @@ index 134ae3f..d390a51 100644
      BYTE(0)	/* d */
      BYTE(0)	/* b */
 diff --git a/winsup/cygwin/dcrt0.cc b/winsup/cygwin/dcrt0.cc
-index 8ddee0c..424441c 100644
+index fda4b58..ccfce50 100644
 --- a/winsup/cygwin/dcrt0.cc
 +++ b/winsup/cygwin/dcrt0.cc
-@@ -377,21 +377,21 @@ check_sanity_and_sync (per_process *p)
+@@ -378,21 +378,21 @@ check_sanity_and_sync (per_process *p)
  
    /* Complain if older than last incompatible change */
    if (p->dll_major < CYGWIN_VERSION_DLL_EPOCH)
@@ -423,7 +404,7 @@ index 8ddee0c..424441c 100644
       which overwrote the cxx_malloc field with the local DLL copy.
       Hilarity ensues if the DLL is not loaded while the process
       is forking. */
-@@ -490,12 +490,12 @@ break_here ()
+@@ -503,12 +503,12 @@ break_here ()
  static void
  initial_env ()
  {
@@ -438,7 +419,7 @@ index 8ddee0c..424441c 100644
      {
        char buf1[PATH_MAX];
        GetModuleFileName (NULL, buf1, PATH_MAX);
-@@ -1101,7 +1101,11 @@ dll_crt0 (per_process *uptr)
+@@ -1148,7 +1148,11 @@ dll_crt0 (per_process *uptr)
     See winsup/testsuite/cygload for an example of how to use cygwin1.dll
     from MSVC and non-cygwin MinGW applications.  */
  extern "C" void
@@ -450,7 +431,7 @@ index 8ddee0c..424441c 100644
  {
  #ifndef __x86_64__
    static char **envp;
-@@ -1314,7 +1318,7 @@ multiple_cygwin_problem (const char *what, uintptr_t magic_version, uintptr_t ve
+@@ -1361,7 +1365,7 @@ multiple_cygwin_problem (const char *what, uintptr_t magic_version, uintptr_t ve
        return;
      }
  
@@ -459,7 +440,7 @@ index 8ddee0c..424441c 100644
      return;
  
    if (CYGWIN_VERSION_MAGIC_VERSION (magic_version) == version)
-@@ -1334,7 +1338,7 @@ are unable to find another cygwin DLL.",
+@@ -1381,7 +1385,7 @@ are unable to find another cygwin DLL.",
  void __reg1
  cygbench (const char *s)
  {
@@ -469,10 +450,10 @@ index 8ddee0c..424441c 100644
  }
  #endif
 diff --git a/winsup/cygwin/devices.cc b/winsup/cygwin/devices.cc
-index c2df919..537bf35 100644
+index fa022ea..df5402b 100644
 --- a/winsup/cygwin/devices.cc
 +++ b/winsup/cygwin/devices.cc
-@@ -308,7 +308,7 @@ const _RDATA _device dev_storage[] =
+@@ -308,7 +308,7 @@ const _RDATA device dev_storage[] =
    {"/dev/fd14", BRACK(FHDEV(DEV_FLOPPY_MAJOR, 14)), "\\Device\\Floppy14", exists_ntdev, S_IFBLK, true},
    {"/dev/fd15", BRACK(FHDEV(DEV_FLOPPY_MAJOR, 15)), "\\Device\\Floppy15", exists_ntdev, S_IFBLK, true},
    {"/dev/full", BRACK(FH_FULL), "\\Device\\Null", exists_ntdev, S_IFCHR, true},
@@ -482,13 +463,13 @@ index c2df919..537bf35 100644
    {"/dev/nst1", BRACK(FHDEV(DEV_TAPE_MAJOR, 129)), "\\Device\\Tape1", exists_ntdev, S_IFBLK, true},
    {"/dev/nst2", BRACK(FHDEV(DEV_TAPE_MAJOR, 130)), "\\Device\\Tape2", exists_ntdev, S_IFBLK, true},
 diff --git a/winsup/cygwin/devices.in b/winsup/cygwin/devices.in
-index 3ec3249..3d2eaf3 100644
+index c337053..0b1067a 100644
 --- a/winsup/cygwin/devices.in
 +++ b/winsup/cygwin/devices.in
-@@ -166,7 +166,7 @@ const _device dev_error_storage =
- "/dev/fd%(0-15)d", BRACK(FHDEV(DEV_FLOPPY_MAJOR, {$1})), "\\Device\\Floppy{$1}", exists_ntdev, S_IFBLK
- "/dev/scd%(0-15)d", BRACK(FHDEV(DEV_CDROM_MAJOR, {$1})), "\\Device\\CdRom{$1}", exists_ntdev, S_IFBLK
- "/dev/sr%(0-15)d", BRACK(FHDEV(DEV_CDROM_MAJOR, {$1})), "\\Device\\CdRom{$1}", exists_ntdev, S_IFBLK
+@@ -176,7 +176,7 @@ const device dev_error_storage =
+ "/dev/sdb%{a-z}s%(1-15)d", BRACK(FH_SDB{uc $1} | {$2}), "\\Device\\Harddisk{52 + ord($1) - ord('a')}\\Partition{$2 % 16}", exists_ntdev, S_IFBLK
+ "/dev/sdc%{a-z}s%(1-15)d", BRACK(FH_SDC{uc $1} | {$2}), "\\Device\\Harddisk{78 + ord($1) - ord('a')}\\Partition{$2 % 16}", exists_ntdev, S_IFBLK
+ "/dev/sdd%{a-x}s%(1-15)d", BRACK(FH_SDD{uc $1} | {$2}), "\\Device\\Harddisk{104 + ord($1) - ord('a')}\\Partition{$2 % 16}", exists_ntdev, S_IFBLK
 -"/dev/kmsg", BRACK(FH_KMSG), "\\Device\\MailSlot\\cygwin\\dev\\kmsg", exists_ntdev, S_IFCHR
 +"/dev/kmsg", BRACK(FH_KMSG), "\\Device\\MailSlot\\msys\\dev\\kmsg", exists_ntdev, S_IFCHR
  %other	{return	NULL;}
@@ -513,10 +494,10 @@ index 255a6d5..4a90293 100644
        if (gfpod_helper (name, real_filename))
  	return true;
 diff --git a/winsup/cygwin/dll_init.cc b/winsup/cygwin/dll_init.cc
-index 0fe5714..418e615 100644
+index 7d01bf9..0647a60 100644
 --- a/winsup/cygwin/dll_init.cc
 +++ b/winsup/cygwin/dll_init.cc
-@@ -691,14 +691,22 @@ dll_dllcrt0_1 (VOID *x)
+@@ -692,14 +692,22 @@ dll_dllcrt0_1 (VOID *x)
     future.  Cygwin can now handle being loaded from a noncygwin app
     using the same entry point. */
  extern "C" int
@@ -540,10 +521,10 @@ index 0fe5714..418e615 100644
    HANDLE retaddr;
    if (_my_tls.isinitialized ())
 diff --git a/winsup/cygwin/dtable.cc b/winsup/cygwin/dtable.cc
-index f464618..e6f560f 100644
+index 0f995e4290..33c886a 100644
 --- a/winsup/cygwin/dtable.cc
 +++ b/winsup/cygwin/dtable.cc
-@@ -965,9 +965,15 @@ handle_to_fn (HANDLE h, char *posix_fn)
+@@ -970,9 +970,15 @@ handle_to_fn (HANDLE h, char *posix_fn)
        if (wcsncasecmp (w32, DEV_NAMED_PIPE, DEV_NAMED_PIPE_LEN) == 0)
  	{
  	  w32 += DEV_NAMED_PIPE_LEN;
@@ -560,10 +541,10 @@ index f464618..e6f560f 100644
  	  w32len = cygheap->installation_key.Length / sizeof (WCHAR);
  	  if (w32len
 diff --git a/winsup/cygwin/exceptions.cc b/winsup/cygwin/exceptions.cc
-index 0f5a890..2677ae7 100644
+index 7ad9988..c07d5df 100644
 --- a/winsup/cygwin/exceptions.cc
 +++ b/winsup/cygwin/exceptions.cc
-@@ -503,14 +503,14 @@ try_to_debug (bool waitloop)
+@@ -509,14 +509,14 @@ try_to_debug (bool waitloop)
    PWCHAR rawenv = GetEnvironmentStringsW () ;
    for (PWCHAR p = rawenv; *p != L'\0'; p = wcschr (p, L'\0') + 1)
      {
@@ -580,46 +561,6 @@ index 0f5a890..2677ae7 100644
  	    }
  	  break;
  	}
-diff --git a/winsup/cygwin/fhandler_tty.cc b/winsup/cygwin/fhandler_tty.cc
-index aba469f..266927f 100644
---- a/winsup/cygwin/fhandler_tty.cc
-+++ b/winsup/cygwin/fhandler_tty.cc
-@@ -464,7 +464,11 @@ fhandler_pty_slave::open (int flags, mode_t)
-       pipe_reply repl;
-       DWORD len;
- 
-+#ifdef __MSYS__
-+      __small_sprintf (buf, "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
-+#else
-       __small_sprintf (buf, "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
-+#endif
- 		       &cygheap->installation_key, get_minor ());
-       termios_printf ("dup handles via master control pipe %s", buf);
-       if (!CallNamedPipe (buf, &req, sizeof req, &repl, sizeof repl,
-@@ -1305,7 +1309,11 @@ fhandler_pty_master::close ()
- 	  pipe_reply repl;
- 	  DWORD len;
- 
-+#ifdef __MSYS__
-+	  __small_sprintf (buf, "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
-+#else
- 	  __small_sprintf (buf, "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
-+#endif
- 			   &cygheap->installation_key, get_minor ());
- 	  acquire_output_mutex (INFINITE);
- 	  if (master_ctl)
-@@ -1770,7 +1778,11 @@ fhandler_pty_master::setup ()
- 
-   /* Create master control pipe which allows the master to duplicate
-      the pty pipe handles to processes which deserve it. */
-+#ifdef __MSYS__
-+  __small_sprintf (buf, "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
-+#else
-   __small_sprintf (buf, "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
-+#endif
- 		   &cygheap->installation_key, unit);
-   master_ctl = CreateNamedPipe (buf, PIPE_ACCESS_DUPLEX
- 				     | FILE_FLAG_FIRST_PIPE_INSTANCE,
 diff --git a/winsup/cygwin/fork.cc b/winsup/cygwin/fork.cc
 index ef5a268..e728b0d 100644
 --- a/winsup/cygwin/fork.cc
@@ -732,10 +673,10 @@ index 56b4363..6bc948a 100644
  
  #endif /* __CYGWIN_CYGWIN_DLL_H__ */
 diff --git a/winsup/cygwin/include/cygwin/version.h b/winsup/cygwin/include/cygwin/version.h
-index 820d28b..1bde8c7 100644
+index 9351ea9..b15773b 100644
 --- a/winsup/cygwin/include/cygwin/version.h
 +++ b/winsup/cygwin/include/cygwin/version.h
-@@ -486,7 +486,11 @@ details. */
+@@ -471,7 +471,11 @@ details. */
     names include the CYGWIN_VERSION_SHARED_DATA version as well as this
     identifier. */
  
@@ -747,7 +688,7 @@ index 820d28b..1bde8c7 100644
  
  /* The Cygwin mount table interface in the Win32 registry also has a version
     number associated with it in case that is changed in a non-backwards
-@@ -502,7 +506,11 @@ details. */
+@@ -487,7 +491,11 @@ details. */
  
  /* Identifiers used in the Win32 registry. */
  
@@ -861,7 +802,7 @@ index 7e763e0..36b4d78 100755
    "END_CYGWIN_VERSION_INFO\n\0";
  cygwin_version_info cygwin_version =
 diff --git a/winsup/cygwin/pinfo.cc b/winsup/cygwin/pinfo.cc
-index 1ce6809..7dbd57e 100644
+index 8e2be32..0291ac8 100644
 --- a/winsup/cygwin/pinfo.cc
 +++ b/winsup/cygwin/pinfo.cc
 @@ -188,7 +188,7 @@ pinfo::maybe_set_exit_code_from_windows ()
@@ -882,22 +823,6 @@ index 1ce6809..7dbd57e 100644
  	  if (realpid == n)
  	    api_fatal ("retrieval of execed process info for pid %d failed due to recursion.", n);
  
-diff --git a/winsup/cygwin/pipe.cc b/winsup/cygwin/pipe.cc
-index 79b7966..36c8953 100644
---- a/winsup/cygwin/pipe.cc
-+++ b/winsup/cygwin/pipe.cc
-@@ -199,7 +199,11 @@ fhandler_pipe::dup (fhandler_base *child, int flags)
-   return res;
- }
- 
-+#ifdef __MSYS__
-+#define PIPE_INTRO "\\\\.\\pipe\\msys-"
-+#else
- #define PIPE_INTRO "\\\\.\\pipe\\cygwin-"
-+#endif
- 
- /* Create a pipe, and return handles to the read and write ends,
-    just like CreatePipe, but ensure that the write end permits
 diff --git a/winsup/cygwin/pseudo-reloc.cc b/winsup/cygwin/pseudo-reloc.cc
 index c250fdc..a230b35 100644
 --- a/winsup/cygwin/pseudo-reloc.cc
@@ -912,10 +837,10 @@ index c250fdc..a230b35 100644
    va_list args;
  
 diff --git a/winsup/cygwin/sec_auth.cc b/winsup/cygwin/sec_auth.cc
-index 468d048..e972e4a 100644
+index 853a07f..c0c343b 100644
 --- a/winsup/cygwin/sec_auth.cc
 +++ b/winsup/cygwin/sec_auth.cc
-@@ -764,7 +764,7 @@ verify_token (HANDLE token, cygsid &usersid, user_groups &groups, bool *pintern)
+@@ -770,7 +770,7 @@ verify_token (HANDLE token, cygsid &usersid, user_groups &groups, bool *pintern)
        if (!NT_SUCCESS (status))
  	debug_printf ("NtQueryInformationToken(), %y", status);
        else
@@ -924,7 +849,7 @@ index 468d048..e972e4a 100644
      }
    /* Verify usersid */
    cygsid tok_usersid (NO_SID);
-@@ -882,7 +882,7 @@ create_token (cygsid &usersid, user_groups &new_groups)
+@@ -888,7 +888,7 @@ create_token (cygsid &usersid, user_groups &new_groups)
    TOKEN_DEFAULT_DACL dacl = {};
    TOKEN_SOURCE source;
    TOKEN_STATISTICS stats;
@@ -933,7 +858,7 @@ index 468d048..e972e4a 100644
    source.SourceIdentifier.HighPart = 0;
    source.SourceIdentifier.LowPart = 0x0101;
  
-@@ -1036,7 +1036,7 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+@@ -1046,7 +1046,7 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
    push_self_privilege (SE_TCB_PRIVILEGE, true);
  
    /* Register as logon process. */
@@ -942,7 +867,7 @@ index 468d048..e972e4a 100644
    SetLastError (0);
    status = LsaRegisterLogonProcess (&name, &lsa_hdl, &sec_mode);
    if (status != STATUS_SUCCESS)
-@@ -1065,10 +1065,10 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
+@@ -1075,10 +1075,10 @@ lsaauth (cygsid &usersid, user_groups &new_groups)
      goto out;
  
    /* Create origin. */
@@ -956,10 +881,10 @@ index 468d048..e972e4a 100644
    ts.SourceIdentifier.LowPart = 0x0103;
  
 diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
-index ba7c743..0ff0b71 100644
+index 6991e06..d6a869f 100644
 --- a/winsup/cygwin/syscalls.cc
 +++ b/winsup/cygwin/syscalls.cc
-@@ -365,7 +365,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+@@ -380,7 +380,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
    /* Create hopefully unique filename.
       Since we have to stick to the current directory on remote shares, make
       the new filename at least very unlikely to match by accident.  It starts
@@ -968,7 +893,7 @@ index ba7c743..0ff0b71 100644
       starting at U+dc00.  Use plain ASCII chars on filesystems not supporting
       Unicode.  The rest of the filename is the inode number in hex encoding
       and a hash of the full NT path in hex.  The combination allows to remove
-@@ -374,7 +374,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+@@ -389,7 +389,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
    RtlAppendUnicodeToString (&recycler,
  			    (pc.fs_flags () & FILE_UNICODE_ON_DISK
  			     && !pc.fs_is_samba ())
@@ -994,7 +919,7 @@ index 81717c6..36d1a1a 100644
  static struct
  {
 diff --git a/winsup/cygwin/winsup.h b/winsup/cygwin/winsup.h
-index 44ea72a..29e845e 100644
+index 369b862..501cd4b 100644
 --- a/winsup/cygwin/winsup.h
 +++ b/winsup/cygwin/winsup.h
 @@ -162,7 +162,11 @@ extern "C" void _pei386_runtime_relocator (per_process *);
@@ -1225,7 +1150,7 @@ index 0ad73fb..63dd4ca 100644
  
  .PHONY: warn_dumper
 diff --git a/winsup/utils/cygcheck.cc b/winsup/utils/cygcheck.cc
-index f6adf51..50a68ec 100644
+index 4f311f2..e7bb826 100644
 --- a/winsup/utils/cygcheck.cc
 +++ b/winsup/utils/cygcheck.cc
 @@ -68,8 +68,7 @@ static const char *known_env_vars[] = {
@@ -1320,7 +1245,7 @@ index f6adf51..50a68ec 100644
    time (&now);
    printf ("Current System Time: %s\n", ctime (&now));
  
-@@ -1640,7 +1639,7 @@ dump_sysinfo ()
+@@ -1672,7 +1671,7 @@ dump_sysinfo ()
  
  
    if (givehelp)
@@ -1329,7 +1254,7 @@ index f6adf51..50a68ec 100644
    for (i = 0; environ[i]; i++)
      {
        char *eq = strchr (environ[i], '=');
-@@ -1690,7 +1689,7 @@ dump_sysinfo ()
+@@ -1722,7 +1721,7 @@ dump_sysinfo ()
    if (registry)
      {
        if (givehelp)
@@ -1338,7 +1263,7 @@ index f6adf51..50a68ec 100644
        scan_registry (0, HKEY_CURRENT_USER,
  		     (char *) "HKEY_CURRENT_USER", 0, false);
        scan_registry (0, HKEY_LOCAL_MACHINE,
-@@ -1874,7 +1873,7 @@ dump_sysinfo ()
+@@ -1906,7 +1905,7 @@ dump_sysinfo ()
    printf ("\n");
  
    if (givehelp)
@@ -1347,7 +1272,7 @@ index f6adf51..50a68ec 100644
    int cygwin_dll_count = 0;
    char cygdll_path[32768];
    for (pathlike *pth = paths; pth->dir; pth++)
-@@ -1891,10 +1890,10 @@ dump_sysinfo ()
+@@ -1923,10 +1922,10 @@ dump_sysinfo ()
  	  wcstombs (f, ffinfo.cFileName, sizeof f);
  	  if (strcasecmp (f + strlen (f) - 4, ".dll") == 0)
  	    {
@@ -1360,7 +1285,7 @@ index f6adf51..50a68ec 100644
  		    {
  		      if (!cygwin_dll_count)
  			strcpy (cygdll_path, pth->dir);
-@@ -1918,9 +1917,9 @@ dump_sysinfo ()
+@@ -1950,9 +1949,9 @@ dump_sysinfo ()
        FindClose (ff);
      }
    if (cygwin_dll_count > 1)
@@ -1372,7 +1297,7 @@ index f6adf51..50a68ec 100644
  
    dump_dodgy_apps (verbose);
  
-@@ -2162,8 +2161,8 @@ static char opts[] = "cdsrvkflphV";
+@@ -2194,8 +2193,8 @@ static char opts[] = "cdsrvkflphV";
  static void
  print_version ()
  {
@@ -1383,7 +1308,7 @@ index f6adf51..50a68ec 100644
  	  "Copyright (C) 1998 - %s Cygwin Authors\n"
  	  "This is free software; see the source for copying conditions.  There is NO\n"
  	  "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n",
-@@ -2193,7 +2192,7 @@ load_cygwin (int& argc, char **&argv)
+@@ -2225,7 +2224,7 @@ load_cygwin (int& argc, char **&argv)
  {
    HMODULE h;
  
@@ -1393,10 +1318,10 @@ index f6adf51..50a68ec 100644
    GetModuleFileNameW (h, cygwin_dll_path, 32768);
    if ((cygwin_internal = (uintptr_t (*) (int, ...))
 diff --git a/winsup/utils/ldd.cc b/winsup/utils/ldd.cc
-index 8e891d8..a7856dc 100644
+index 233d650..43a0747 100644
 --- a/winsup/utils/ldd.cc
 +++ b/winsup/utils/ldd.cc
-@@ -246,7 +246,7 @@ tocyg (wchar_t *win_fn)
+@@ -265,7 +265,7 @@ tocyg (wchar_t *win_fn)
    return fn;
  }
  
@@ -1495,7 +1420,7 @@ index 548b89a..09ee26d 100644
      "The \"-b\" means 'skip the help pages'.  You can omit this until you're\n"
      "familiar with the report layout.  The gprof documentation explains\n"
 diff --git a/winsup/utils/strace.cc b/winsup/utils/strace.cc
-index 5d4a23d..0c8d75e 100644
+index 3042d1b..5c7f030 100644
 --- a/winsup/utils/strace.cc
 +++ b/winsup/utils/strace.cc
 @@ -281,7 +281,7 @@ load_cygwin ()
@@ -1507,7 +1432,7 @@ index 5d4a23d..0c8d75e 100644
      {
        errno = ENOENT;
        return 0;
-@@ -351,14 +351,14 @@ create_child (char **argv)
+@@ -352,14 +352,14 @@ create_child (char **argv)
    make_command_line (one_line, argv);
  
    SetConsoleCtrlHandler (NULL, 0);
@@ -1525,7 +1450,7 @@ index 5d4a23d..0c8d75e 100644
    _putenv (newenv);
    ret = CreateProcess (0, one_line.buf,	/* command line */
  		       NULL,	/* Security */
-@@ -783,7 +783,7 @@ dotoggle (pid_t pid)
+@@ -780,7 +780,7 @@ dotoggle (pid_t pid)
    child_pid = (DWORD) cygwin_internal (CW_CYGWIN_PID_TO_WINPID, pid);
    if (!child_pid)
      {
@@ -1535,5 +1460,5 @@ index 5d4a23d..0c8d75e 100644
      }
    if (cygwin_internal (CW_STRACE_TOGGLE, child_pid))
 -- 
-2.9.0
+2.9.1
 

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=2.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -48,7 +48,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0023-path.cc-Ignore-zero-length-exclusions.patch)
 sha256sums=('SKIP'
             'e873a7414ebcd66d9871ccda7c830eb3002f95266f9cc29a48d8c1982664e1db'
-            '52e3d85f141c93ab0ec303a5e4455163217f272af8c4c9bb2eb2f0485515fe98'
+            '398a8b2e80ffd43c6ced75b73472eda1b92ce082616683e2822d6276108de67a'
             'b2e2a6d95cc817b94a93966615e86d97ea42786554993bfdd5dc7bdce476950a'
             'ebc4f62b283b4adfd4a4be25e660b263b6489a753ebbe8ba58ec1ba15201b3e1'
             'd581ecd093d9bb94dff87b6499d13b432759e071f64c40fdccdf5c17c195cc3a'


### PR DESCRIPTION
This is a patch for MSYS runtime.
Allows for simpler is-it-mintty-stdin pipe name test.

Implied on mingw-w64 mailing list.
Untested.