### PR TITLE
Add the core Styrene repacker tool

### DIFF
--- a/styrene-git/PKGBUILD
+++ b/styrene-git/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Andrew Chadwick <a.t.chadwick@gmail.com>
+
+_realname=styrene
+pkgname=${_realname}-git
+pkgver=0.1.0.4.g06accfb
+pkgrel=1
+pkgdesc="Repacks MSYS2 packages into installer .exes and standalone .zips."
+url="https://github.com/achadwick/styrene"
+arch=('i686' 'x86_64')
+provides=("${_realname}")
+conflicts=("${_realname}")
+makedepends=('git')
+depends=(
+    'python3'
+    'python3-pyalpm'
+    'zip'
+)
+license=('GPLv3+')
+source=("${_realname}::git+https://github.com/achadwick/styrene.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}"/${_realname}
+    git describe --tags | sed 's,-\(alpha\|beta\),\1,' \
+      | sed 's,-,.,g' | sed 's,^v,,'
+}
+
+prepare() {
+    cd "${srcdir}"/${_realname}
+    git reset --hard HEAD
+    git clean -fx
+}
+
+build() {
+    cd "${srcdir}"/${_realname}
+    python3 setup.py build
+}
+
+package() {
+    cd "${srcdir}"/${_realname}
+    python3 setup.py install --prefix="/usr" --root="${pkgdir}"
+    install -Dm644 COPYING "${pkgdir}"/usr/share/licenses/${_realname}/COPYING
+}


### PR DESCRIPTION
I wrote a developer tool for bundling up combinations of local native builds and binary MSYS packages into convenient app bundles shaped for regular Windows users. "All" developers need to do is maintain their normal .desktop files and write a config file for their app; the Styrene tool takes care of all the repackaging and installer-making details.

https://github.com/achadwick/styrene

Would it be OK to incorporate this early draft of the tool into MSYS2-packages in -git form initially?