### PR TITLE
expat - 2.2.0 - Add expat-2.2.0-CVE-2016-0718-regression.patch from A…

### DIFF
--- a/expat/PKGBUILD
+++ b/expat/PKGBUILD
@@ -2,19 +2,22 @@
 
 pkgname=('expat' 'libexpat' 'libexpat-devel')
 pkgver=2.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An XML parser library"
 arch=('i686' 'x86_64')
 url="http://expat.sourceforge.net/"
 license=('custom')
 source=(https://downloads.sourceforge.net/sourceforge/expat/${pkgname}-${pkgver}.tar.bz2
-        msys2-expat-2.1.1.patch)
+        msys2-expat-2.1.1.patch
+        expat-2.2.0-CVE-2016-0718-regression.patch)
 sha256sums=('d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff'
-            '11102bf0c6271e4d9667ed1b45e3a006e06cf074438a2a8b5e4d9316e0a34f13')
+            '11102bf0c6271e4d9667ed1b45e3a006e06cf074438a2a8b5e4d9316e0a34f13'
+            'e64ff17753e601f23a6825beeb930aef1bec17b7eec7dce4e8c465b3c0cd66ff')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
   patch -p1 -i ${srcdir}/msys2-expat-2.1.1.patch
+  patch -p2 -i ${srcdir}/expat-2.2.0-CVE-2016-0718-regression.patch
   rm -f m4/*
 
   autoreconf -vfi

--- a/expat/expat-2.2.0-CVE-2016-0718-regression.patch
+++ b/expat/expat-2.2.0-CVE-2016-0718-regression.patch
@@ -1,0 +1,27 @@
+From 3e6190e433479e56f8c1e5adc1198b3c86b15577 Mon Sep 17 00:00:00 2001
+From: Sebastian Pipping <sebastian@pipping.org>
+Date: Sun, 17 Jul 2016 20:22:29 +0200
+Subject: [PATCH] Fix regression introduced by patch to CVE-2016-0718 (bug
+ #539)
+
+Tag names were cut off in some cases; reported by Andy Wang
+---
+ expat/lib/xmlparse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/expat/lib/xmlparse.c b/expat/lib/xmlparse.c
+index 13e080d..2630310 100644
+--- a/expat/lib/xmlparse.c
++++ b/expat/lib/xmlparse.c
+@@ -2430,7 +2430,7 @@ doContent(XML_Parser parser,
+                        &fromPtr, rawNameEnd,
+                        (ICHAR **)&toPtr, (ICHAR *)tag->bufEnd - 1);
+             convLen = (int)(toPtr - (XML_Char *)tag->buf);
+-            if ((convert_res == XML_CONVERT_COMPLETED) || (convert_res == XML_CONVERT_INPUT_INCOMPLETE)) {
++            if ((fromPtr >= rawNameEnd) || (convert_res == XML_CONVERT_INPUT_INCOMPLETE)) {
+               tag->name.strLen = convLen;
+               break;
+             }
+-- 
+2.9.2
+

--- a/libarchive/PKGBUILD
+++ b/libarchive/PKGBUILD
@@ -36,8 +36,8 @@ build() {
     --prefix=/usr \
     --enable-shared \
     --enable-static \
-    --without-libiconv-prefix
-
+    --without-libiconv-prefix \
+    --without-xml2
   make
   make DESTDIR="${srcdir}/dest" install
 }


### PR DESCRIPTION
…rchlinux

Tag names were cut off in some cases; reported by Andy Wang
libarchive - 3.2.2 - use expat instead of libxml2