### PR TITLE
binutils: re-enable weak NT externals patches

### DIFF
--- a/binutils/0001-coff-linker-weak-nt-externals.patch
+++ b/binutils/0001-coff-linker-weak-nt-externals.patch
@@ -1,5 +1,90 @@
+From f2922a47c8e0f858649d5867df3eff9186bac583 Mon Sep 17 00:00:00 2001
+From: Octavian Purdila <octavian dot purdila at intel dot com>
+Date: Mon, 26 Oct 2015 15:57:33 +0200
+Subject: [PATCH 1/3] Fix linker error when using NT weak externals
+
+Lets take the following example:
+
+a.c:
+	void foo(void);
+
+	int main()
+	{
+		foo();
+			return 0;
+	}
+
+b.c:
+	#include <stdio.h>
+
+	void __attribute__((weak)) foo(void)
+	{
+		printf("%s weak\n", __func__);
+	}
+
+Compiling this with mingw will trigger the following linker error:
+
+$ i686-w64-mingw32-gcc -o a.exe a.c b.c
+/tmp/ccZ6Yw7O.o:a.c:(.text+0xc): undefined reference to `foo'
+collect2: error: ld returned 1 exit status
+
+Depending on the order in which a.c and b.c are linked the following
+is happening in _bfd_generic_link_add_one_symbol:
+
+1. If we link in a.c b.c order then foo will be added in as an
+undefined symbol from a.c. Then it will be added as a weak undefined*
+symbol from b.c (section undefined, flags BSF_WEAK) and the action
+taken will be no action, i.e. keep the symbol undefined.
+
+2. If we link in b.c a.c order then foo will first be added as an
+undefined weak symbol from b.c. Then it will be added as undefined
+from a.c and the action taken will be to make the symbol undefined.
+
+To fix this issue, this patch checks for an weak external symbol when
+doing relocations even if the symbol is undefined. In order to do so,
+we also have to also populate the symbol_class and aux members when
+adding a weak external symbol over an undefined or weak defined
+symbol.
+
+*In PE COFF case defined weak symbols are implemented as weak
+externals which requires them to be seen as undefined (weak) symbols.
+
+bfd/
+
+2015-10-26  Octavian Purdila  <octavian.purdila@intel.com>
+
+    * cofflink.c: Move weak external relocation code to a new function
+    (_bfd_coff_relocate_weak_externals)
+    * cofflink.c (_bfd_coff_generic_relocate_section): Check if we
+    need to relocate a weak external even if the symbol is undefined
+    * cofflink.c (coff_link_add_symbols): Fill in the class and aux
+    when adding a weak external over an undefined or weakly defined
+    symbol
+---
+ bfd/ChangeLog  | 10 +++++++++
+ bfd/cofflink.c | 66 ++++++++++++++++++++++++++++++++--------------------------
+ 2 files changed, 46 insertions(+), 30 deletions(-)
+
+diff --git a/bfd/ChangeLog b/bfd/ChangeLog
+index 96152768ab..b5b5df1b13 100644
+--- a/bfd/ChangeLog
++++ b/bfd/ChangeLog
+@@ -1,3 +1,13 @@
++2015-10-26  octavian purdila  <octavian.purdila@intel.com>
++
++	* cofflink.c: Move weak external relocation code to a new function
++	(_bfd_coff_relocate_weak_externals)
++	* cofflink.c (_bfd_coff_generic_relocate_section): Check if we
++	need to relocate a weak external even if the symbol is undefined
++	* cofflink.c (coff_link_add_symbols): Fill in the class and aux
++	when adding a weak external over an undefined or weakly defined
++	symbol
++
+ 2015-07-21  Tristan Gingold  <gingold@adacore.com>
+ 
+ 	* version.m4: Bump version to 2.25.1
 diff --git a/bfd/cofflink.c b/bfd/cofflink.c
-index 8d98fec..8f76b4d 100644
+index ef9e3623fe..caed7e4aa9 100644
 --- a/bfd/cofflink.c
 +++ b/bfd/cofflink.c
 @@ -426,7 +426,7 @@ coff_link_add_symbols (bfd *abfd,
@@ -26,22 +111,22 @@ index 8d98fec..8f76b4d 100644
 +   generic_link_check_archive_element. */
 +
 +static void _bfd_coff_relocate_weak_externals(struct coff_link_hash_entry *h,
-+					      bfd_vma *val, asection **sec)
++					      bfd_vma *val)
 +{
 +  long aux_index = h->aux->x_sym.x_tagndx.l;
 +  struct coff_tdata *cdata = h->auxbfd->tdata.coff_obj_data;
 +  struct coff_link_hash_entry *h2 = cdata->sym_hashes[aux_index];
++  asection *sec;
 +
 +  if (!h2 || h2->root.type == bfd_link_hash_undefined)
 +    {
-+      *sec = bfd_abs_section_ptr;
 +      *val = 0;
 +    }
 +  else
 +    {
-+      *sec = h2->root.u.def.section;
-+      *val = h2->root.u.def.value + (*sec)->output_section->vma +
-+	      (*sec)->output_offset;
++      sec = h2->root.u.def.section;
++      *val = h2->root.u.def.value + sec->output_section->vma +
++	      sec->output_offset;
 +    }
 +}
 +
@@ -49,7 +134,7 @@ index 8d98fec..8f76b4d 100644
  /* A basic reloc handling routine which may be used by processors with
     simple relocs.  */
  
-@@ -2999,38 +3030,14 @@ _bfd_coff_generic_relocate_section (bfd *output_bfd,
+@@ -3007,39 +3038,14 @@ _bfd_coff_generic_relocate_section (bfd *output_bfd,
  	  else if (h->root.type == bfd_link_hash_undefweak)
  	    {
                if (h->symbol_class == C_NT_WEAK && h->numaux == 1)
@@ -64,6 +149,7 @@ index 8d98fec..8f76b4d 100644
 -		     will resolve a weak external only if a normal
 -		     external causes the library member to be linked.
 -		     See also linker.c: generic_link_check_archive_element. */
+-		  asection *sec;
 -		  struct coff_link_hash_entry *h2 =
 -		    h->auxbfd->tdata.coff_obj_data->sym_hashes[
 -		    h->aux->x_sym.x_tagndx.l];
@@ -80,7 +166,7 @@ index 8d98fec..8f76b4d 100644
 -			+ sec->output_section->vma + sec->output_offset;
 -		    }
 -		}
-+	        _bfd_coff_relocate_weak_externals(h, &val, &sec);
++	        _bfd_coff_relocate_weak_externals(h, &val);
  	      else
                  /* This is a GNU extension.  */
  		val = 0;
@@ -88,9 +174,10 @@ index 8d98fec..8f76b4d 100644
 -
 +	  else if (h->root.type == bfd_link_hash_undefined &&
 +		   h->symbol_class == C_NT_WEAK && h->numaux == 1)
-+	    _bfd_coff_relocate_weak_externals(h, &val, &sec);
- 	  else if (! bfd_link_relocatable (info))
++	    _bfd_coff_relocate_weak_externals(h, &val);
+ 	  else if (! info->relocatable)
  	    {
  	      if (! ((*info->callbacks->undefined_symbol)
 -- 
-2.1.0
+2.11.0
+

--- a/binutils/0002-gas-aux-nt-weak-externals.patch
+++ b/binutils/0002-gas-aux-nt-weak-externals.patch
@@ -1,5 +1,101 @@
+From 20932eba3b856aec9ad15b8a5f6220dce10bf1fa Mon Sep 17 00:00:00 2001
+From: Octavian Purdila <octavian dot purdila at intel dot com>
+Date: Mon, 26 Oct 2015 15:57:34 +0200
+Subject: [PATCH 2/3] Relocate aux entries for NT weak externals
+
+Currently the tagndx for NT weak externals are not relocated when
+creating a relocatable object which breaks relocations when doing the
+final link of the relocatable object.
+
+For the following example:
+
+    a.c:
+        void foo(void);
+
+            int main()
+            {
+                    foo();
+                    return 0;
+            }
+
+    b.c:
+            #include <stdio.h>
+
+            void __attribute__((weak)) foo(void)
+            {
+                    printf("%s weak\n", __func__);
+            }
+
+$ i686-w64-mingw32-ld -r -o r.o a.o b.o
+
+This is how the symbol table looks for b.o:
+
+$ i686-w64-mingw32-objdump -x b.o | grep -A 1 foo
+[ 23](sec  1)(fl 0x00)(ty   0)(scl   2) (nx 0) 0x00000000 .weak._foo.
+[ 24](sec  0)(fl 0x00)(ty  20)(scl 105) (nx 1) 0x00000000 _foo
+
+And this is how the symbol table table looks for r.o:
+
+$ i686-w64-mingw32-objdump -x r.o | grep -A 1 foo
+[ 45](sec  0)(fl 0x00)(ty  20)(scl 105) (nx 1) 0x00000000 _foo
+AUX lnno 1 size 0x0 tagndx 23
+...
+[ 48](sec  1)(fl 0x00)(ty   0)(scl   2) (nx 0) 0x00000000 .weak._foo.
+
+As you can see the AUX entry for _foo is wrong in r.o, it should be 48
+but it is 23.
+
+The patch uses the sym_indices array to relocate the AUX entries for
+weak externals in _bfd_coff_link_input_bfd.
+
+In order to do so we need the .weak. counterpart symbol to be loaded
+before the weak external symbol. This is prevented by by the ISFCN()
+check _bfd_coff_link_input_bfd and is caused by the fact that the AUX
+entry type is 0. To fix this issue we patch gas to propagate the type
+of external weak symbols to its .weak. counterpart symbol.
+
+Note that we perform the AUX tag relocations only int the case of
+relocatable output because weak external relocation handling
+(_bfd_coff_generic_relocate_section) uses the tagndx relative to the
+input object.
+
+bfd/
+
+2015-10-26  Octavian Purdila  <octavian.purdila@intel.com>
+
+    * cofflink.c (_bfd_coff_link_input_bfd): relocate AUX entries for
+    weak externals when generating relocatable objects
+
+gas/
+
+2015-10-26 Octavian Purdila  <octavian.purdila@intel.com>
+
+    * obj-coff.c (coff_frob_symbol): propagate the type of external
+    weak symbol to its .weak. counterpart
+---
+ bfd/ChangeLog         |  5 +++++
+ bfd/cofflink.c        | 14 +++++++++++---
+ gas/ChangeLog         |  5 +++++
+ gas/config/obj-coff.c |  1 +
+ 4 files changed, 22 insertions(+), 3 deletions(-)
+
+diff --git a/bfd/ChangeLog b/bfd/ChangeLog
+index b5b5df1b13..7c78023d7b 100644
+--- a/bfd/ChangeLog
++++ b/bfd/ChangeLog
+@@ -1,5 +1,10 @@
+ 2015-10-26  octavian purdila  <octavian.purdila@intel.com>
+ 
++	* cofflink.c (_bfd_coff_link_input_bfd): relocate AUX entries for
++	weak externals when generating relocatable objects
++
++2015-10-26  Octavian Purdila  <octavian.purdila@intel.com>
++
+ 	* cofflink.c: Move weak external relocation code to a new function
+ 	(_bfd_coff_relocate_weak_externals)
+ 	* cofflink.c (_bfd_coff_generic_relocate_section): Check if we
 diff --git a/bfd/cofflink.c b/bfd/cofflink.c
-index 8f76b4d..f9b591a 100644
+index caed7e4aa9..ce5c583b3f 100644
 --- a/bfd/cofflink.c
 +++ b/bfd/cofflink.c
 @@ -1944,7 +1944,8 @@ _bfd_coff_link_input_bfd (struct coff_final_link_info *flaginfo, bfd *input_bfd)
@@ -22,7 +118,7 @@ index 8f76b4d..f9b591a 100644
 +	        {
 +		    long *tagndx = &auxp->x_sym.x_tagndx.l;
 +
-+		    if (bfd_link_relocatable (flaginfo->info) &&
++		    if (flaginfo->info->relocatable &&
 +			flaginfo->sym_indices[*tagndx] > 0)
 +		      *tagndx = flaginfo->sym_indices[*tagndx];
 +		}
@@ -30,11 +126,24 @@ index 8f76b4d..f9b591a 100644
  		{
  		  unsigned long indx;
  
+diff --git a/gas/ChangeLog b/gas/ChangeLog
+index 75df4f646a..2bb66bb5e1 100644
+--- a/gas/ChangeLog
++++ b/gas/ChangeLog
+@@ -1,3 +1,8 @@
++2015-10-26 Octavian Purdila  <octavian.purdila@intel.com>
++
++	* obj-coff.c (coff_frob_symbol): propagate the type of external
++	weak symbol to its .weak. counterpart
++
+ 2015-07-21  Tristan Gingold  <gingold@adacore.com>
+ 
+ 	* configure: Regenerate.
 diff --git a/gas/config/obj-coff.c b/gas/config/obj-coff.c
-index c0a3f1f..ac2310c 100644
+index 9f5a903ae6..578120d225 100644
 --- a/gas/config/obj-coff.c
 +++ b/gas/config/obj-coff.c
-@@ -1277,6 +1277,7 @@ coff_frob_symbol (symbolS *symp, int *punt)
+@@ -1280,6 +1280,7 @@ coff_frob_symbol (symbolS *symp, int *punt)
  					   symbol_get_value_expression (weakp));
  	      symbol_set_frag (symp, symbol_get_frag (weakp));
  	      S_SET_SEGMENT (symp, S_GET_SEGMENT (weakp));
@@ -43,4 +152,5 @@ index c0a3f1f..ac2310c 100644
  	  else
  	    {
 -- 
-2.1.0
+2.11.0
+

--- a/binutils/0003-objcopy-weak-nt-externals2local.patch
+++ b/binutils/0003-objcopy-weak-nt-externals2local.patch
@@ -1,8 +1,65 @@
+From bc03e2e40e51474f2244f5909f3e8f5a4cf60ab0 Mon Sep 17 00:00:00 2001
+From: Octavian Purdila <octavian dot purdila at intel dot com>
+Date: Mon, 26 Oct 2015 15:57:35 +0200
+Subject: [PATCH 3/3] Convert NT weak externals to locals
+
+This patch allows converting a weak external symbol to a local symbol
+by setting up its section and value to the ones of the alternate
+symbol. This is useful when we want to make only a few selected
+symbols visible (e.g. objcopy -G).
+
+The conversion is triggered when an NT weak external symbol has been
+marked with BSF_LOCAL.
+
+bfd/
+
+2015-10-22  Octavian Purdila <octavian.purdila@intel.com>
+
+    * coffgen.c: add coff_nt_weak_to_local() that implements weak
+      external to local symbol conversion
+    * coffcode.h (coff_write_object_contents): call
+      coff_nt_weak_to_local()
+    * libcoff.h: add coff_nt_weak_to_local() declaration
+
+binutils/
+
+2015-10-26  Octavian Purdila <octavian.purdila@intel.com>
+
+    * objcopy.c (filter_symbols): allow converting undefined weak
+    symbols to local symbols for PE objects (as PE weak externals are
+    implemented as undefined weak symbols)
+---
+ bfd/ChangeLog      |  8 ++++++++
+ bfd/coffcode.h     |  1 +
+ bfd/coffgen.c      | 43 +++++++++++++++++++++++++++++++++++++++++++
+ bfd/libcoff.h      |  2 ++
+ binutils/ChangeLog |  6 ++++++
+ binutils/objcopy.c |  5 ++++-
+ 6 files changed, 64 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/ChangeLog b/bfd/ChangeLog
+index 7c78023d7b..a4ba816cb9 100644
+--- a/bfd/ChangeLog
++++ b/bfd/ChangeLog
+@@ -1,5 +1,13 @@
+ 2015-10-26  octavian purdila  <octavian.purdila@intel.com>
+ 
++	* coffgen.c: add coff_nt_weak_to_local() that implements weak
++	external to local symbol conversion
++	* coffcode.h (coff_write_object_contents): call
++	coff_nt_weak_to_local()
++	* libcoff.h: add coff_nt_weak_to_local() declaration
++
++2015-10-26  Octavian Purdila <octavian.purdila@intel.com>
++
+ 	* cofflink.c (_bfd_coff_link_input_bfd): relocate AUX entries for
+ 	weak externals when generating relocatable objects
+ 
 diff --git a/bfd/coffcode.h b/bfd/coffcode.h
-index 2499885..fc61dee 100644
+index 2b1c3d053f..23d932018d 100644
 --- a/bfd/coffcode.h
 +++ b/bfd/coffcode.h
-@@ -4202,6 +4202,7 @@ coff_write_object_contents (bfd * abfd)
+@@ -4198,6 +4198,7 @@ coff_write_object_contents (bfd * abfd)
      {
        int firstundef;
  
@@ -11,10 +68,10 @@ index 2499885..fc61dee 100644
  	return FALSE;
        coff_mangle_symbols (abfd);
 diff --git a/bfd/coffgen.c b/bfd/coffgen.c
-index 9257f73..dd05823 100644
+index d071d8a36f..cd2a502963 100644
 --- a/bfd/coffgen.c
 +++ b/bfd/coffgen.c
-@@ -788,6 +788,49 @@ coff_renumber_symbols (bfd *bfd_ptr, int *first_undef)
+@@ -801,6 +801,49 @@ coff_renumber_symbols (bfd *bfd_ptr, int *first_undef)
    return TRUE;
  }
  
@@ -32,7 +89,7 @@ index 9257f73..dd05823 100644
 +      combined_entry_type *native;
 +      struct internal_syment *sym;
 +
-+      coff_symbol_ptr = coff_symbol_from (symbol);
++      coff_symbol_ptr = coff_symbol_from (abfd, symbol);
 +      if (!coff_symbol_ptr)
 +        continue;
 +
@@ -65,23 +122,37 @@ index 9257f73..dd05823 100644
     pointers to entries are changed to the entries' index in the output
     symbol table.  */
 diff --git a/bfd/libcoff.h b/bfd/libcoff.h
-index 124e603..3ccf4d6 100644
+index 947998570b..08cf93ac7d 100644
 --- a/bfd/libcoff.h
 +++ b/bfd/libcoff.h
-@@ -309,6 +309,8 @@ extern long coff_canonicalize_symtab
-   (bfd *, asymbol **);
- extern int coff_count_linenumbers
+@@ -326,6 +326,8 @@ extern int coff_count_linenumbers
    (bfd *);
+ extern struct coff_symbol_struct *coff_symbol_from
+   (bfd *, asymbol *);
 +extern void coff_nt_weak_to_local
 +  (bfd *);
  extern bfd_boolean coff_renumber_symbols
    (bfd *, int *);
  extern void coff_mangle_symbols
+diff --git a/binutils/ChangeLog b/binutils/ChangeLog
+index a23a6c3713..07a824e260 100644
+--- a/binutils/ChangeLog
++++ b/binutils/ChangeLog
+@@ -1,3 +1,9 @@
++2015-10-26  Octavian Purdila <octavian.purdila@intel.com>
++
++	* objcopy.c (filter_symbols): allow converting undefined weak
++	symbols to local symbols for PE objects (as PE weak externals are
++	implemented as undefined weak symbols)
++
+ 2015-07-21  Tristan Gingold  <gingold@adacore.com>
+ 
+ 	* configure: Regenerate.
 diff --git a/binutils/objcopy.c b/binutils/objcopy.c
-index 2cd55fd..94b7702 100644
+index da429f54ea..d064119da0 100644
 --- a/binutils/objcopy.c
 +++ b/binutils/objcopy.c
-@@ -1372,7 +1372,10 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
+@@ -1336,7 +1336,10 @@ filter_symbols (bfd *abfd, bfd *obfd, asymbol **osyms,
  	      sym->flags |= BSF_WEAK;
  	    }
  
@@ -94,4 +165,5 @@ index 2cd55fd..94b7702 100644
  	      && (is_specified_symbol (name, localize_specific_htab)
  		  || (htab_elements (keepglobal_specific_htab) != 0
 -- 
-2.1.0
+2.11.0
+

--- a/binutils/PKGBUILD
+++ b/binutils/PKGBUILD
@@ -26,9 +26,9 @@ source=(#https://www.mirrorservice.org/sites/sourceware.org/pub/binutils/snapsho
         )
 sha256sums=('b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22'
             'SKIP'
-            '76663a2493f81e2306140259a2e4306b7cc4592fc4381951df87b5aa52c0fb62'
-            'a5764911df3bde0e51fe2c244cac38a2f4169081017796b8cc9f214d34c17930'
-            '05933fb77e5577257fe1d7a6ff2e701e93fd43ce417a29165bc6a71da5326459'
+            '2236889a2570b628d9b630aa60bc57c2abc07e072b5a4568bb5af86c9e1cea0b'
+            '15717eefc02275611f8a2af112d2bd08e030fabd06c3d3f6070fd15dc56c54e7'
+            '1db81bba67d4f254af567b4a23b4645c335b14e985dc59c930e124fe89dc2a25'
             '3ac2dccb420a2f86bb7341de9b2b1a43e2bb6065ce54b600b1bd63c7de3e01b9'
             'bd38317b28b894d5c0e0ba043fc2445af415f6e96bb9ac93c348748d21a43625'
             '0d99572e111e06446c4e4bc834d318a6bfa7946d4169b6169197317b1bcc5f09'
@@ -36,9 +36,9 @@ sha256sums=('b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22'
 
 prepare() {
   cd "${srcdir}"/binutils-$_basever
-  #patch -p1 -i "${srcdir}"/0001-coff-linker-weak-nt-externals.patch
-  #patch -p1 -i "${srcdir}"/0002-gas-aux-nt-weak-externals.patch
-  #patch -p1 -i "${srcdir}"/0003-objcopy-weak-nt-externals2local.patch
+  patch -p1 -i "${srcdir}"/0001-coff-linker-weak-nt-externals.patch
+  patch -p1 -i "${srcdir}"/0002-gas-aux-nt-weak-externals.patch
+  patch -p1 -i "${srcdir}"/0003-objcopy-weak-nt-externals2local.patch
   #patch -p1 -i "${srcdir}"/0004-fix-erroneous-relocations-applied.patch
   #patch -p1 -i "${srcdir}"/0050-bfd-Increase-_bfd_coff_max_nscns-to-65279.patch
   #patch -p1 -i "${srcdir}"/0100-binutils-2.26-msys2.patch


### PR DESCRIPTION
The rollback to 2.25.1 (https://github.com/Alexpux/MSYS2-packages/commit/660ffd3fd117a22f3dff71d80edf56ad4a188c26) caused those patches to be disabled. The commit mentions some instability of 2.26 but I couldn't find more information on what specifically was unstable. 

I rebased the weak NT externals patches on 2.25.1.