### PR TITLE
msys2-runtime: better workaround for GCC 6

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=2.6.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -116,8 +116,8 @@ build() {
     OPTIM="-O2"
   fi
 
-  CFLAGS="$OPTIM -pipe -ggdb -Wno-error=frame-address -Wno-error=nonnull-compare"
-  CXXFLAGS="$OPTIM -pipe -ggdb -Wno-error=frame-address -Wno-error=nonnull-compare"
+  CFLAGS="$OPTIM -pipe -ggdb -Wno-error=frame-address -fno-delete-null-pointer-checks"
+  CXXFLAGS="$OPTIM -pipe -ggdb -Wno-error=frame-address -fno-delete-null-pointer-checks"
 
   "${srcdir}"/msys2-runtime/configure \
     --prefix=/usr \


### PR DESCRIPTION
As @jan-hudec noticed we have to disable null pointer optimization until Cygwin fixes their code.
Closes https://github.com/Alexpux/MSYS2-packages/issues/793

Zsh doesn't crash, tested with:
```
mati865@DESKTOP-0J8VPHJ MSYS ~
$ zsh -c 'FOO=$(echo foo)'

mati865@DESKTOP-0J8VPHJ MSYS ~
$
```