### PR TITLE
fish: update to 2.5.0

### DIFF
--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Masanori Shirayama <mashir43@gmail.com>
 
 pkgname=fish
-pkgver=2.4.0
+pkgver=2.5.0
 pkgrel=1
 epoch=
 pkgdesc="a smart and user-friendly command line shell"
@@ -9,13 +9,13 @@ arch=('i686' 'x86_64')
 url="https://fishshell.com/"
 license=('GPL')
 groups=()
-depends=('gcc-libs' 'ncurses' 'gettext' 'libiconv')
+depends=('gcc-libs' 'ncurses' 'gettext' 'libiconv' 'man-db')
 makedepends=('gcc' 'ncurses-devel' 'gettext-devel' 'intltool' 'libiconv-devel' 'doxygen')
 optdepends=('python: for manual page completion parser and web configuration tool')
 install=fish.install
 source=("https://fishshell.com/files/$pkgver/$pkgname-$pkgver.tar.gz"
         01-msysize.patch)
-sha256sums=('06bbb2323360439c4044da762d114ec1aa1aba265cec71c0543e6a0095c9efc5'
+sha256sums=('f8c0edadca2de379ccf305aeace660a9255fa2180c72e85e97705a24c256b2a5'
             '1e2743177c499e890d681be685fed6f849e42cb282e13b4e56324169a43bd987')
 
 prepare() {


### PR DESCRIPTION
Additional Changes:
* add dependency on `man-db`
  - `fish` uses `apropos.exe` at tab-completion