### PR TITLE
Also source /etc/profile.d/*.sh for zsh

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 # Contributor: Karlson2k (Evgeny Grin) <k2k@narod.ru>
+# Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
 pkgver=2017.02
-pkgrel=3
+pkgrel=4
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -61,7 +62,7 @@ sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
             'db22c5b21b1ee38ff978557754b59f3847f69d63f03d60cb664de4a816793810'
             '3c1da9bf6ff791c32f17e49db0047b3c9cbaacd44d6d0b92696cdeacebf8f947'
             '91f1f918cf13deab0124082086e990786113b0e710dbda4678d8fc14905ad94d'
-            '24f4cd302d495d286134be5bd2466a1bef19c70e7ed825d0b61e49adcf3ad664'
+            '4973827f59fed69911bc0b3e4ad7f9ee6aac0ee120b38ded0a46a7302044dd36'
             '0a3a3b131ace34f11f428118dfe81b34da148e29b6bea3b027d79bebd47141a7'
             '020d0619a6af9a4d6e1068cb77f2789bcf470380426214e90177f5596d651835'
             '756df34c5b28478a81331785de0f56438bb652cf5f29029a9db2d83281361340'

--- a/filesystem/profile
+++ b/filesystem/profile
@@ -134,6 +134,7 @@ elif [ ! "x${KSH_VERSION}" = "x" ]; then
   PS1=$(print '\033]0;${PWD}\n\033[32m${USER}@${HOSTNAME} \033[33m${PWD/${HOME}/~}\033[0m\n$ ')
 elif [ ! "x${ZSH_VERSION}" = "x" ]; then
   HOSTNAME="$(/usr/bin/hostname)"
+  profile_d sh
   profile_d zsh
   PS1='(%n@%m)[%h] %~ %% '
 elif [ ! "x${POSH_VERSION}" = "x" ]; then


### PR DESCRIPTION
I discovered that zsh as a login shell does not source `/etc/profile.d/lang.sh` and `/etc/profile.d/tzset.sh`. I think this behavior should mirror the upstream behavior in the Arch [`/etc/profile`](https://git.archlinux.org/svntogit/packages.git/tree/trunk/profile?h=packages/filesystem) and source `/etc/profile.d/*.sh` when running zsh.

I didn't change `/etc/profile` to stop sourcing `*.zsh`, in case someone's configuration was depending on it.