### PR TITLE
Fix missing bracket in cmake FindBoost

### DIFF
--- a/cmake/PKGBUILD
+++ b/cmake/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cmake
 pkgver=3.6.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system"
 arch=('i686' 'x86_64')
 url="https://www.cmake.org/"
@@ -30,7 +30,7 @@ source=("https://www.cmake.org/files/v3.6/${pkgname}-${pkgver}.tar.gz"
         "3.6.0-cpuinfo.patch"
         "3.5.2-cygwin-paths.patch")
 sha256sums=('189ae32a6ac398bb2f523ae77f70d463a6549926cde1544cd9cc7c6609f8b346'
-            '557cc21c94e9d62df9d0938644d37e9d20683fc3f1f4bc2b6bc16fb8834347f5'
+            'fb2dcd43cdaf994d071a7a6607c3c4972a862d5654ab6782153001a0db474c06'
             'b7e398e70b97088f88a0688e8a0794d6780d3cdb91075388a30908dc4b405eb7'
             '98dca846de0ca7b71884e26678317f85e78e01862d58a29ce923c835ca7d614f'
             'd4a48c98919bd35e3f8c7c5c3b0ea1615b41294b26015ecfa3de7fa6db1e5d75'

--- a/cmake/cmake-3.6.0-msys.patch
+++ b/cmake/cmake-3.6.0-msys.patch
@@ -386,7 +386,7 @@ diff -aur cmake-3.6.0/Modules/FindBoost.cmake.orig cmake-3.6.0/Modules/FindBoost
  set(Boost_LIB_PREFIX "")
  if ( (GHSMULTI AND Boost_USE_STATIC_LIBS) OR
 -    (WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN) )
-+    ( WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN AND NOT MSYS)
++    ( WIN32 AND Boost_USE_STATIC_LIBS AND NOT CYGWIN AND NOT MSYS) )
    set(Boost_LIB_PREFIX "lib")
  endif()
  


### PR DESCRIPTION
The patch used in PKGBUILD for cmake missed a bracket. This is a regression and had been already fixed in #646.