### PR TITLE
Update pass to 1.7 and add libqrencode package

### DIFF
--- a/libqrencode-git/PKGBUILD
+++ b/libqrencode-git/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: micbou <contact@micbou.com>
+
+pkgname=libqrencode-git
+pkgver=v3.4.3.r238.ge3410bf
+pkgrel=1
+pkgdesc='QR Code encoding library'
+arch=('i686' 'x86_64')
+url='http://fukuchi.org/works/qrencode/'
+license=('LGPL')
+makedepends=('git' 'gcc')
+provides=("${pkgname%-git}")
+conflicts=("${pkgname%-git}")
+source=(git+https://github.com/fukuchi/libqrencode)
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${pkgname%-git}"
+  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd "${srcdir}/${pkgname%-git}"
+  ./autogen.sh
+  ./configure
+  make LDFLAGS="${LDFLAGS} -no-undefined"
+}
+
+package() {
+  cd "${srcdir}/${pkgname%-git}"
+  make install
+}

--- a/pass/PKGBUILD
+++ b/pass/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: micbou <contact@micbou.com>
 
 pkgname='pass'
-pkgver=1.6.5
-pkgrel=2
+pkgver=1.7
+pkgrel=1
 pkgdesc='Stores, retrieves, generates, and synchronizes passwords securely'
 arch=('any')
 url='https://www.passwordstore.org'
 license=('GPL2')
-depends=('bash' 'gnupg' 'pwgen' 'tree')
-optdepends=('git: for Git support')
+depends=('bash' 'gnupg' 'tree')
+optdepends=('git: Git support'
+            'libqrencode: QR Code support')
 source=(https://git.zx2c4.com/password-store/snapshot/password-store-${pkgver}.tar.xz)
-sha256sums=('337a39767e6a8e69b2bcc549f27ff3915efacea57e5334c6068fcb72331d7315')
+sha256sums=('161ac3bd3c452a97f134aa7aa4668fe3f2401c839fd23c10e16b8c0ae4e15500')
 
 package() {
   cd "${srcdir}/password-store-$pkgver/"
-  make DESTDIR="${pkgdir}" FORCE_ALL=1 install
+  make install
 }


### PR DESCRIPTION
Pass 1.7 dropped the pwgen dependency and added an optional dependency: [libqrencode](http://fukuchi.org/works/qrencode/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexpux/msys2-packages/833)
<!-- Reviewable:end -->
