### PR TITLE
enable HTTPS for sf.net pacman mirror

### DIFF
--- a/pacman-mirrors/mirrorlist.mingw32
+++ b/pacman-mirrors/mirrorlist.mingw32
@@ -5,6 +5,5 @@
 ## Primary
 ## msys2.org
 Server = http://repo.msys2.org/mingw/i686
-Server = http://downloads.sourceforge.net/project/msys2/REPOS/MINGW/i686
+Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/i686
 Server = http://www2.futureware.at/~nickoe/msys2-mirror/mingw/i686
-

--- a/pacman-mirrors/mirrorlist.mingw64
+++ b/pacman-mirrors/mirrorlist.mingw64
@@ -5,6 +5,5 @@
 ## Primary
 ## msys2.org
 Server = http://repo.msys2.org/mingw/x86_64
-Server = http://downloads.sourceforge.net/project/msys2/REPOS/MINGW/x86_64
+Server = https://downloads.sourceforge.net/project/msys2/REPOS/MINGW/x86_64
 Server = http://www2.futureware.at/~nickoe/msys2-mirror/mingw/x86_64
-

--- a/pacman-mirrors/mirrorlist.msys
+++ b/pacman-mirrors/mirrorlist.msys
@@ -5,6 +5,5 @@
 ## Primary
 ## msys2.org
 Server = http://repo.msys2.org/msys/$arch
-Server = http://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/$arch
+Server = https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/$arch
 Server = http://www2.futureware.at/~nickoe/msys2-mirror/msys/$arch/
-


### PR DESCRIPTION
It is useful, now that HTTPS got enabled on all mirrors,
according to: https://sourceforge.net/blog/small-but-significant-changes-to-project-pages/