### PR TITLE
rsync: Use included zlib

### DIFF
--- a/rsync/PKGBUILD
+++ b/rsync/PKGBUILD
@@ -29,8 +29,7 @@ build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   ./configure \
       --build=${CHOST} \
-      --prefix=/usr \
-      --without-included-zlib
+      --prefix=/usr
   
   make reconfigure
   make man all


### PR DESCRIPTION
Using the system's zlib disables -z.

The default is to use the included zlib, which is compatible with older
rsync versions.

Arch also doesn't pass --without-included-zlib[1].

[1] https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/rsync