### PR TITLE
Taskbar-pinnable mintty

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2017.02
-pkgrel=4
+pkgver=2017.03
+pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
 license=('BSD')
@@ -49,7 +49,7 @@ source=('bash.bash_logout'
         'mingw32-config.site'
         'redirect-config.site')
 sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
-            '4995deb0c6a2b5482ba62759f1f5bcdd19186528d99d263dc8bc61d42878798e'
+            'e9b85a053e2c1f0fee53f6fa66cb6ff55a960dd7555ca179731a5564b221c534'
             '99eae6e37081edd73b399009c85f4a67a0c14481241ee4937ab45c4178b540fb'
             'ed08a8bd0919ba29ec5dd2d0c74ba74324ca2bcbf7852354b0b6c523809029a0'
             '4330edf340394d0dae50afb04ac2a621f106fe67fb634ec81c4bfb98be2a1eb5'

--- a/filesystem/bash.bashrc
+++ b/filesystem/bash.bashrc
@@ -43,6 +43,7 @@ unset _warning
 # if a PS1 is already set and exported, use that;
 # otherwise set a default prompt
 # of user@host, MSYSTEM variable, and current_directory
+# Also tell mintty the current directory with \e]7; so that Alt-F2 inherits it.
 [[ -n "${MSYS2_PS1}" ]] && export PS1="${MSYS2_PS1}"
 # if we have the "High Mandatory Level" group, it means we're elevated
 if [[ -n "$(command -v getent)" ]] && id -G | grep -q "$(getent -w group 'S-1-16-12288' | cut -d: -f2)"
@@ -50,7 +51,7 @@ if [[ -n "$(command -v getent)" ]] && id -G | grep -q "$(getent -w group 'S-1-16
   else _ps1_symbol='\$'
 fi
 [[ $(declare -p PS1 2>/dev/null | cut -c 1-11) = 'declare -x ' ]] || \
-  export PS1='\[\e]0;\w\a\]\n\[\e[32m\]\u@\h \[\e[35m\]$MSYSTEM\[\e[0m\] \[\e[33m\]\w\[\e[0m\]\n'"${_ps1_symbol}"' '
+  export PS1='\[\e]0;\w\a\]\n\[\e[32m\]\u@\h \[\e[35m\]$MSYSTEM\[\e[0m\] \[\e[33m\]\w\[\e[0m\]\n\[\e]7;$PWD\a\]'"${_ps1_symbol}"' '
 unset _ps1_symbol
 
 # Uncomment to use the terminal colours set in DIR_COLORS

--- a/mintty/0002-add-msys2-launcher.patch
+++ b/mintty/0002-add-msys2-launcher.patch
@@ -1,0 +1,325 @@
+From b40367fec8f658d74a8c74dfdd223293c7828b85 Mon Sep 17 00:00:00 2001
+From: Mihail Konev <k.mvc@ya.ru>
+Date: Sat, 4 Mar 2017 07:43:42 +0500
+Subject: [PATCH 2/3] add msys2 launcher
+
+Also makes mintty pinnable to Windows Taskbar.
+
+Before, a pinned shortcut would have generic icon and fail to launch a
+proper shell because of $MSYSTEM not being set.
+
+The list of shells is harcoded.  An editable config file in /etc would
+be nice (for e.g. "MSYS2 zsh" item), but this works for now.
+
+Usage notes:
+
+If the taskbar cannot forget mintty's default icon, rebooting helps
+(at least, non-fast-restart one).
+
+If the taskbar cannot forget the mintty's default "Terminal" tooltip
+text displayed upon mouse hover of the shorcut, deleting the
+
+ [HKEY_CLASSES_ROOT\Local Settings\Software\Microsoft\Windows\Shell\MuiCache]
+ "C:\\path\\to\\msys\\usr\\bin\\mintty.exe.FriendlyAppName"
+
+registry value (or just the entire MuiCache directory) should help, at
+least for the current Windows 10.
+---
+ src/appinfo.h  |   2 +-
+ src/launcher.c | 129 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/launcher.h |  12 ++++++
+ src/res.h      |   4 ++
+ src/res.rc     |  16 ++++++-
+ src/winmain.c  |  34 ++++++++++++---
+ 6 files changed, 189 insertions(+), 8 deletions(-)
+ create mode 100644 src/launcher.c
+ create mode 100644 src/launcher.h
+
+diff --git a/src/appinfo.h b/src/appinfo.h
+index eebc47a..2877d69 100644
+--- a/src/appinfo.h
++++ b/src/appinfo.h
+@@ -10,7 +10,7 @@
+ #define BUILD_NUMBER   0
+ 
+ // needed for res.rc
+-#define APPDESC "Terminal"
++#define APPDESC "MSYS2 terminal"
+ #define AUTHOR  "Andy Koppe / Thomas Wolff"
+ #define YEAR    "2013/2016"
+ 
+diff --git a/src/launcher.c b/src/launcher.c
+new file mode 100644
+index 0000000..e120708
+--- /dev/null
++++ b/src/launcher.c
+@@ -0,0 +1,129 @@
++#include <windows.h>
++#include <commctrl.h>
++#include "res.h"
++
++#define INSIDE_LAUNCHER
++#include "launcher.h"
++
++static char ***ret_argv_addr;
++
++int launcher_cancelled = 0;
++
++void launcher_init(char ***argv_addr) {
++  ret_argv_addr = argv_addr;
++}
++
++void launcher_free(void) {
++  return;
++}
++
++static int selected_btn = IDD_MSYS2_BTN;
++
++void launcher_setup_env(void) {
++  switch (selected_btn) {
++  case IDD_MINGW32_BTN:
++    putenv("MSYSTEM=MINGW32");
++    break;
++  case IDD_MINGW64_BTN:
++    putenv("MSYSTEM=MINGW64");
++    break;
++  default:
++    putenv("MSYSTEM=MSYS");
++    break;
++  }
++  return;
++}
++
++static char *bash_cmd[] = {
++  "/usr/bin/bash", "--login", NULL
++};
++
++void launcher_setup_argv(void) {
++  *ret_argv_addr = bash_cmd;
++}
++
++static void launcher_add_tooltip_to_window(HWND hwnd, char *text) {
++  TOOLINFO ti;
++  RECT rect;
++  HWND hwnd_tt;
++
++  hwnd_tt = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS, NULL,
++      WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
++      0, 0, 0, 0, hwnd, NULL, NULL, NULL );
++
++  SetWindowPos(hwnd_tt, HWND_TOPMOST, 0, 0, 0, 0,
++      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
++
++  GetClientRect(hwnd, &rect);
++
++  ti.cbSize = sizeof(TOOLINFO);
++  ti.uFlags = TTF_SUBCLASS;
++  ti.hwnd = hwnd;
++  ti.hinst = NULL;
++  ti.uId = 0;
++  ti.lpszText = text;
++  ti.rect.left = rect.left;
++  ti.rect.top = rect.top;
++  ti.rect.right = rect.right;
++  ti.rect.bottom = rect.bottom;
++
++  SendMessage(hwnd_tt, TTM_ADDTOOL, 0, (LPARAM) (LPTOOLINFO) &ti);
++}
++
++static void launcher_add_tooltip_to_window_by_id(HWND dialog, int id, char *text) {
++  HWND hwnd;
++
++  hwnd = GetDlgItem(dialog, id);
++  launcher_add_tooltip_to_window(hwnd, text);
++}
++
++static void launcher_add_tooltips(HWND hwnd) {
++  launcher_add_tooltip_to_window(hwnd,
++      "MSYS2 shell launcher");
++  launcher_add_tooltip_to_window_by_id(hwnd, IDD_MSYS2_BTN,
++      "The emulated shell, for running and building Msys2-specific apps.");
++  launcher_add_tooltip_to_window_by_id(hwnd, IDD_MINGW32_BTN,
++      "32-bit shell, for running and building native apps.");
++  launcher_add_tooltip_to_window_by_id(hwnd, IDD_MINGW64_BTN,
++      "64-bit shell, for running and building native apps.");
++}
++
++HICON launcher_icon;
++
++INT_PTR CALLBACK launcher_dlgproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
++  (void) lParam;
++
++  switch (uMsg) { /* handle the messages */
++  case WM_COMMAND:
++    switch (LOWORD(wParam)) {
++    case IDCANCEL:
++      SendMessage(hwnd, WM_CLOSE, 0, 0);
++      launcher_cancelled = 1;
++      return TRUE;
++    case IDD_MSYS2_BTN:
++    case IDD_MINGW32_BTN:
++    case IDD_MINGW64_BTN:
++      DestroyWindow(hwnd);
++      selected_btn = LOWORD(wParam);
++      return TRUE;
++    default:
++      return FALSE;
++    }
++    break;
++  case WM_INITDIALOG:
++    SendMessage(hwnd, WM_SETICON, 0, (LPARAM)launcher_icon);
++    launcher_add_tooltips(hwnd);
++    return TRUE;
++  case WM_DESTROY:
++    break;
++  case WM_CLOSE:
++    DestroyWindow(hwnd);
++    launcher_cancelled = 1;
++    return TRUE;
++  default:
++    return FALSE;
++  }
++
++  return FALSE;
++}
++
+diff --git a/src/launcher.h b/src/launcher.h
+new file mode 100644
+index 0000000..619508a
+--- /dev/null
++++ b/src/launcher.h
+@@ -0,0 +1,12 @@
++#ifndef INSIDE_LAUNCHER
++extern int launcher_cancelled;
++extern HICON launcher_icon;
++#endif
++
++void launcher_init(char ***argv_addr);
++void launcher_free(void);
++
++void launcher_setup_env(void);
++void launcher_setup_argv(void);
++
++INT_PTR CALLBACK launcher_dlgproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+diff --git a/src/res.h b/src/res.h
+index da4a06b..df37fa6 100644
+--- a/src/res.h
++++ b/src/res.h
+@@ -23,3 +23,7 @@
+ //#define DIALOG_FONT "Trebuchet MS"
+ //#define DIALOG_FONT "Lucida Sans Unicode"
+ 
++#define IDD_LAUNCHER         0x100
++#define IDD_MSYS2_BTN        0x101
++#define IDD_MINGW32_BTN      0x102
++#define IDD_MINGW64_BTN      0x103
+diff --git a/src/res.rc b/src/res.rc
+index 642b086..2373606 100644
+--- a/src/res.rc
++++ b/src/res.rc
+@@ -4,7 +4,7 @@
+ 
+ #include <winresrc.h>
+ 
+-IDI_MAINICON ICON "../icon/terminal.ico"
++IDI_MAINICON ICON "/msys2.ico"
+ 
+ IDD_MAINBOX DIALOGEX DISCARDABLE 32, 8, DIALOG_WIDTH, DIALOG_HEIGHT
+ STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+@@ -14,6 +14,20 @@ CLASS DIALOG_CLASS
+ BEGIN
+ END
+ 
++IDD_LAUNCHER DIALOGEX 0, 0, 100, 97
++STYLE DS_3DLOOK | DS_CENTER | DS_SYSMODAL | DS_SHELLFONT | WS_CAPTION | WS_VISIBLE | WS_POPUP | WS_SYSMENU
++EXSTYLE WS_EX_TOPMOST | WS_EX_APPWINDOW
++CAPTION "Mintty"
++FONT 8, "Ms Shell Dlg"
++{
++    GROUPBOX        "Shells (bash)", 0, 3, 5, 92, 69, 0, WS_EX_LEFT
++    PUSHBUTTON      "MSYS2",            IDD_MSYS2_BTN,   9, 16, 44, 14, 0, WS_EX_LEFT
++    PUSHBUTTON      "Mingw-w64 32 bit", IDD_MINGW32_BTN, 9, 35, 74, 14, 0, WS_EX_LEFT
++    PUSHBUTTON      "Mingw-w64 64 bit", IDD_MINGW64_BTN, 9, 54, 74, 14, 0, WS_EX_LEFT
++
++    PUSHBUTTON      "Cancel", IDCANCEL, 25, 78, 44, 14, NOT WS_TABSTOP, WS_EX_LEFT
++}
++
+ /*
+  * The actual VERSIONINFO resource.
+  */
+diff --git a/src/winmain.c b/src/winmain.c
+index 7af432f..0ccca9a 100644
+--- a/src/winmain.c
++++ b/src/winmain.c
+@@ -33,6 +33,9 @@
+ #include <propkey.h>
+ #endif
+ 
++#include "res.h"
++#include "launcher.h"
++
+ 
+ char * home;
+ char * cmd;
+@@ -2548,6 +2551,8 @@ main(int argc, char *argv[])
+     }
+   }
+ 
++  launcher_icon = large_icon ?: LoadIcon(inst, MAKEINTRESOURCE(IDI_MAINICON));
++
+   // The window class.
+   class_atom = RegisterClassExW(&(WNDCLASSEXW){
+     .cbSize = sizeof(WNDCLASSEXW),
+@@ -2556,7 +2561,7 @@ main(int argc, char *argv[])
+     .cbClsExtra = 0,
+     .cbWndExtra = 0,
+     .hInstance = inst,
+-    .hIcon = large_icon ?: LoadIcon(inst, MAKEINTRESOURCE(IDI_MAINICON)),
++    .hIcon = launcher_icon,
+     .hIconSm = small_icon,
+     .hCursor = LoadCursor(null, IDC_IBEAM),
+     .hbrBackground = null,
+@@ -2564,7 +2569,6 @@ main(int argc, char *argv[])
+     .lpszClassName = wclass,
+   });
+ 
+-
+   // Initialise the fonts, thus also determining their width and height.
+   win_init_fonts(cfg.font.size);
+ 
+@@ -2772,10 +2776,28 @@ main(int argc, char *argv[])
+ #endif
+   }
+ 
+-  // Create child process.
+-  child_create(
+-    argv, &(struct winsize){term_rows, term_cols, term_width, term_height}
+-  );
++  {
++    char **argv1 = argv;
++
++    if (argc == 1) {
++      launcher_init(&argv1);
++      DialogBox(inst, MAKEINTRESOURCE(IDD_LAUNCHER), NULL, (DLGPROC)launcher_dlgproc);
++      if (launcher_cancelled) {
++        exit(1);
++      }
++      launcher_setup_env();
++      launcher_setup_argv();
++    }
++
++    // Create child process.
++    child_create(
++      argv1, &(struct winsize){term_rows, term_cols, term_width, term_height}
++    );
++
++    if (argc == 1) {
++      launcher_free();
++    }
++  }
+ 
+   // Finally show the window!
+   go_fullscr_on_max = (cfg.window == -1);
+-- 
+2.11.0
+

--- a/mintty/0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch
+++ b/mintty/0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch
@@ -1,0 +1,57 @@
+From 85fb3c828a59cdbe2aefef762c10a8bc0237c53a Mon Sep 17 00:00:00 2001
+From: Mihail Konev <k.mvc@ya.ru>
+Date: Sun, 5 Mar 2017 22:58:09 +0500
+Subject: [PATCH 3/3] fix current dir inheritance for alt-f2 on msys2
+
+---
+ src/child.c   |  2 ++
+ src/winmain.c | 13 +++++++++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/src/child.c b/src/child.c
+index 11de61a..ba0f6e1 100644
+--- a/src/child.c
++++ b/src/child.c
+@@ -808,6 +808,8 @@ child_fork(int argc, char *argv[], int moni)
+     // propagate shortcut-inherited icon
+     if (icon_is_from_shortcut)
+       setenv("MINTTY_ICON", cs__wcstoutf(cfg.icon), true);
++    // tell alt-f2 mintty instance that it is such one
++    setenv("MINTTY_IS_CHILD", "1", 1);
+ 
+ #if CYGWIN_VERSION_DLL_MAJOR >= 1005
+     execv("/proc/self/exe", argv);
+diff --git a/src/winmain.c b/src/winmain.c
+index 0ccca9a..789b09e 100644
+--- a/src/winmain.c
++++ b/src/winmain.c
+@@ -2185,6 +2185,12 @@ opts[] = {
+   {0, 0, 0, 0}
+ };
+ 
++static int getenvi(const char *varname) {
++  char *s = getenv(varname);
++  if (s == NULL) { return 0; }
++  return atoi(s);
++}
++
+ int
+ main(int argc, char *argv[])
+ {
+@@ -2788,6 +2794,13 @@ main(int argc, char *argv[])
+       launcher_setup_env();
+       launcher_setup_argv();
+     }
++    // Ask /etc/post-install/05-home-dir.post not to "cd ~/" in an Alt-F2 window
++    {
++      if (getenvi("MINTTY_IS_CHILD")) {
++        putenv("CHERE_INVOKING=1");
++      }
++      unsetenv("MINTTY_IS_CHILD");
++    }
+ 
+     // Create child process.
+     child_create(
+-- 
+2.11.0
+

--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mintty
 pkgver=2.7.3
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
 arch=('i686' 'x86_64')
@@ -11,13 +11,19 @@ groups=('base')
 depends=('sh')
 url="https://mintty.github.io"
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
-        001-fix-identation-without-guard.patch)
+        001-fix-identation-without-guard.patch
+        0002-add-msys2-launcher.patch
+        0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch)
 sha256sums=('eeaa5e2b5ed68354ae2dbea3ce4998cbbd620f13b330ab64383fd4e7e6b89e47'
-            'bc6011ebaa214083b6f15c6f21f217b79435139e549891b49cfd1380651a8c19')
+            'bc6011ebaa214083b6f15c6f21f217b79435139e549891b49cfd1380651a8c19'
+            '2206240168fa481e54346406e96820a1e0a678a9cc21076bd8fac4c97c527dd4'
+            'd2398c8586c8eaa04dc2f49d663855f420a17feec918f6ac63a8b975037cd86c')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/001-fix-identation-without-guard.patch
+  patch -p1 -i ${srcdir}/0002-add-msys2-launcher.patch
+  patch -p1 -i ${srcdir}/0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch
 }
 
 build() {


### PR DESCRIPTION
Adds a shell selection dialog that pops up when the terminal is launched without command line arguments, as well as duplicated with `Alt-F2`. For the latter use case, this also fixes `cd ~` by `/etc`.