### PR TITLE
msys2-runtime: Allow unprivileged symlink

### DIFF
--- a/msys2-runtime/0024-Allow-unprivileged-symlink.patch
+++ b/msys2-runtime/0024-Allow-unprivileged-symlink.patch
@@ -1,0 +1,28 @@
+From 8696868b113e1c2325b8ba5363e90f3634da1106 Mon Sep 17 00:00:00 2001
+From: Einbert-Xeride <einbert-xeride@outlook.com>
+Date: Tue, 25 Apr 2017 00:27:14 +0800
+Subject: [PATCH] Allow unprivileged symlink
+
+---
+ winsup/cygwin/path.cc | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/winsup/cygwin/path.cc b/winsup/cygwin/path.cc
+index ee7636dbf..2304db8f5 100644
+--- a/winsup/cygwin/path.cc
++++ b/winsup/cygwin/path.cc
+@@ -1725,8 +1725,9 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
+	 }
+   /* Try to create native symlink. */
+   if (!CreateSymbolicLinkW (final_newpath->Buffer, final_oldpath->Buffer,
+-				win32_oldpath.isdir ()
+-				? SYMBOLIC_LINK_FLAG_DIRECTORY : 0))
++				(win32_oldpath.isdir ()
++				? SYMBOLIC_LINK_FLAG_DIRECTORY : 0)
++				| 0x2 /* SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE */ ))
+	 {
+	   /* Repair native newpath, we still need it. */
+	   final_newpath->Buffer[1] = L'?';
+-- 
+2.12.2
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -45,7 +45,8 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0020-Add-debugging-for-build_argv.patch
         0021-Add-debugging-for-strace-make_command_line.patch
         0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch
-        0023-path.cc-Ignore-zero-length-exclusions.patch)
+        0023-path.cc-Ignore-zero-length-exclusions.patch
+        0024-allow-unprivileged-symlink.patch)
 sha256sums=('SKIP'
             'b1c5301bbb7a99b69ad6e5cb89f383f59d349ec7c7913060213c78d4550c7bb7'
             'e1acc70d775bb32844d7ac471db1820433103dee2fed527f85768439d57cf730'
@@ -69,7 +70,8 @@ sha256sums=('SKIP'
             '9e844186fb1e0cb7612a412968623c8ab2339a6dd768927733a571672a2bfb54'
             'a7866fd6bf627477b52112a24d5504fb75678e334c9cd283f176d5820b1dea55'
             '7afc2bac55c3db92a7f849a497113d82be7966d3e8bb4793e30ed006ef7229e0'
-            '98ff1fb66a962ab2365222333acd6b148d44d47fd919971fea81f2ba4482b6f5')
+            '98ff1fb66a962ab2365222333acd6b148d44d47fd919971fea81f2ba4482b6f5'
+            'b7aceb3a6633a84666258e39dcb87b1bc503e8aa9a43bd1da7398a45efda27f2')
 prepare() {
   cd "${srcdir}"/msys2-runtime
   git am --committer-date-is-author-date "${srcdir}"/0001-Add-MSYS-triplets.patch
@@ -95,6 +97,7 @@ prepare() {
   git am --committer-date-is-author-date "${srcdir}"/0021-Add-debugging-for-strace-make_command_line.patch
   git am --committer-date-is-author-date "${srcdir}"/0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch
   git am --committer-date-is-author-date "${srcdir}"/0023-path.cc-Ignore-zero-length-exclusions.patch
+  git am --committer-date-is-author-date "${srcdir}"/0024-allow-unprivileged-symlink.patch
 }
 
 build() {


### PR DESCRIPTION
Tested on Windows 10 Pro (15063.138) x64 and Windows 7 Pro x64.

Added a patch to enable new behavior of symbolic link introduced in Windows 10 Creators Update. (https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/)