### PR TITLE
gcc: fix c89/c99 scripts

### DIFF
--- a/gcc/PKGBUILD
+++ b/gcc/PKGBUILD
@@ -296,7 +296,7 @@ for opt; do
 	    exit 1;;
   esac
 done
-exec /usr/bin/gcc \$fl \${1+"\$@"}
+exec /usr/bin/gcc $fl ${1+"$@"}
 EOF
 
   cat > ${pkgdir}/usr/bin/c99 <<"EOF"
@@ -309,7 +309,7 @@ for opt; do
 	    exit 1;;
   esac
 done
-exec /usr/bin/gcc \$fl \${1+"\$@"}
+exec /usr/bin/gcc $fl ${1+"$@"}
 EOF
 
   chmod 755 ${pkgdir}/usr/bin/c{8,9}9


### PR DESCRIPTION
remove the bogus escape of the $ character

Fixes issue #886 