### PR TITLE
improve sourceware.org vcs protocols

### DIFF
--- a/crypt/PKGBUILD
+++ b/crypt/PKGBUILD
@@ -10,7 +10,7 @@ arch=('i686' 'x86_64')
 license=('custom')
 url="https://cygwin.com/"
 makedepends=('gcc' 'git' 'make')
-source=(${pkgbase}-${pkgver}::git://sourceware.org/git/cygwin-apps/crypt.git#tag=${pkgbase}-${pkgver//./_}-release
+source=(${pkgbase}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/crypt.git#tag=${pkgbase}-${pkgver//./_}-release
         msysize.patch)
 sha256sums=('SKIP'
             '13746ef5eb4d37e74b4a8ae85430e5f80836e3f1fae72cb0b5f5bd7c5c398240')

--- a/cygrunsrv/PKGBUILD
+++ b/cygrunsrv/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('gcc' 'git' 'make')
 source=(${pkgname}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/${pkgname}.git#tag=rel${pkgver//./-}
         msysize.patch)
 sha256sums=(SKIP
-            'd3c9f9dcc081d40d7624deed53ad29d0b4d90eb0d873f92a5519b5a0bef90ee6')
+            '270b2015b1dad8008cbc7e66c3ae724fd2d3b51d93bfceefe3895de7cd340c6a')
 
 prepare(){
   cd ${pkgname}-${pkgver}

--- a/cygrunsrv/PKGBUILD
+++ b/cygrunsrv/PKGBUILD
@@ -10,7 +10,7 @@ url="https://cygwin.org/"
 license=('GPL')
 depends=('python2')
 makedepends=('gcc' 'git' 'make')
-source=(${pkgname}-${pkgver}::git://sourceware.org/git/cygwin-apps/${pkgname}.git#tag=rel${pkgver//./-}
+source=(${pkgname}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/${pkgname}.git#tag=rel${pkgver//./-}
         msysize.patch)
 sha256sums=(SKIP
             'd3c9f9dcc081d40d7624deed53ad29d0b4d90eb0d873f92a5519b5a0bef90ee6')

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -22,7 +22,7 @@ makedepends=('cocom'
              'libiconv-devel'
              'diffutils')
 # options=('debug' '!strip')
-source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release
+source=('msys2-runtime'::git+https://sourceware.org/git/newlib-cygwin.git#tag=cygwin-${pkgver//./_}-release
         0001-Add-MSYS-triplets.patch
         0002-Rename-DLL-from-cygwin-to-msys.patch
         0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch

--- a/rebase/PKGBUILD
+++ b/rebase/PKGBUILD
@@ -11,7 +11,7 @@ url="https://www.cygwin.com/"
 depends=('msys2-runtime' 'dash')
 makedepends=('coreutils' 'git' 'grep' 'gzip' 'sed')
 # options=('debug' '!strip')
-source=(${pkgname}-${pkgver}::git://sourceware.org/git/cygwin-apps/rebase.git#tag=${pkgname}-${pkgver//./-}
+source=(${pkgname}-${pkgver}::git+https://sourceware.org/git/cygwin-apps/rebase.git#tag=${pkgname}-${pkgver//./-}
         'rebase-4.4.1-msys2.patch'
         'autorebase.bat'
         'autorebasebase1st.bat'

--- a/windows-default-manifest/PKGBUILD
+++ b/windows-default-manifest/PKGBUILD
@@ -7,23 +7,15 @@ pkgdesc='Default Windows application manifest'
 url='https://cygwin.com/'
 arch=('i686' 'x86_64')
 license=('BSD')
-makedepends=('cvs' 'gcc')
-source=(001-msysize.patch)
-sha256sums=('0baef1e5f9b980cdf730386a652b6b02ba6b675cc120ad67c7c15e6a88050e0f')
-CVSROOT=":pserver:anoncvs:@sourceware.org:/cvs/cygwin-apps"
-CVSMOD="windows-default-manifest"
-CVS_BRANCH="release-${pkgver//\./_}"
+makedepends=('git' 'gcc')
+_GIT_TAG="release-6_4"
+source=("git://sourceware.org/git/cygwin-apps/${_realname}.git#tag=${_GIT_TAG}"
+        001-msysize.patch)
+sha256sums=('SKIP'
+            '0baef1e5f9b980cdf730386a652b6b02ba6b675cc120ad67c7c15e6a88050e0f')
 
 prepare() {
-  cd ${srcdir}
-  msg "Connecting to sourceware.org CVS server...."
-  if [ -d $CVSMOD/CVS ]; then
-    cd $CVSMOD
-    cvs -z3 update -d
-  else
-    cvs -z3 -d $CVSROOT co -r $CVS_BRANCH -f $CVSMOD
-    cd $CVSMOD
-  fi
+  cd ${srcdir}/${pkgname}
 
   patch -p1 -i ${srcdir}/001-msysize.patch
   autoreconf -fiv


### PR DESCRIPTION
https://sourceware.org/git/cygwin-apps/windows-default-manifest.git doesn't seem to work, but it does with unencrypted Git protocols, which is an improvement over CVS.
