### PR TITLE
pass: Update to 1.7.1

### DIFF
--- a/pass/PKGBUILD
+++ b/pass/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: micbou <contact@micbou.com>
 
 pkgname='pass'
-pkgver=1.7
+pkgver=1.7.1
 pkgrel=1
 pkgdesc='Stores, retrieves, generates, and synchronizes passwords securely'
 arch=('any')
@@ -11,7 +11,7 @@ depends=('bash' 'gnupg' 'tree')
 optdepends=('git: Git support'
             'libqrencode: QR Code support')
 source=(https://git.zx2c4.com/password-store/snapshot/password-store-${pkgver}.tar.xz)
-sha256sums=('161ac3bd3c452a97f134aa7aa4668fe3f2401c839fd23c10e16b8c0ae4e15500')
+sha256sums=('f6d2199593398aaefeaa55e21daddfb7f1073e9e096af6d887126141e99d9869')
 
 package() {
   cd "${srcdir}/password-store-$pkgver/"


### PR DESCRIPTION
[Pass 1.7.1 was released](https://lists.zx2c4.com/pipermail/password-store/2017-April/002892.html) a few weeks ago.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexpux/msys2-packages/895)
<!-- Reviewable:end -->
