### PR TITLE
openssh: bump to 7.5p1

### DIFF
--- a/openssh/PKGBUILD
+++ b/openssh/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=openssh
-pkgver=7.3p1
-pkgrel=2
+pkgver=7.5p1
+pkgrel=1
 pkgdesc='Free version of the SSH connectivity tools'
 url='http://www.openssh.org/portable.html'
 license=('custom:BSD')
@@ -15,7 +15,7 @@ source=("http://mirrors.mit.edu/pub/OpenBSD/OpenSSH/portable/${pkgname}-${pkgver
         openssh-7.3p1-msys2-setkey.patch
         openssh-7.3p1-msys2-skip-privsep-tests.patch
         openssh-7.3p1-msys2-drive-name-in-path.patch)
-sha256sums=('3ffb989a6dcaa69594c3b550d4855a5a2e1718ccdde7f5e36387b424220fbecc'
+sha256sums=('9846e3c5fab9f0547400b4d2c017992f914222b3fd1f8eee6c7dc6bc5e59f9f0'
             'ab54293758c908bfdcd95b338bad5eb35290291e957dc99bc09fae4f906987fc'
             '25079cf4a10c1ab70d60302bccaabee513762520dffd7c35285f7aae3ea36087'
             '729aa8ef3723a223afbd1bda678a7deaca75b5c3b42a74b1a8c396f95f8677b5'
@@ -35,6 +35,7 @@ prepare() {
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
+  TEST_SSH_UTF8=no \
   ./configure \
     --build=${CHOST} \
     --prefix=/usr \


### PR DESCRIPTION
For some reason, the test_utf8 tests fail here, probably because
snmprintf() does not return what OpenSSH expects... But UTF-8 is not
native to Windows anyway (at least not yet).

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>