### PR TITLE
Fix segfault on user autocomplete in zsh

### DIFF
--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -21,7 +21,7 @@ source=("https://downloads.sourceforge.net/project/zsh/zsh/${pkgver}/zsh-${pkgve
         user-autocomplete.patch)
 sha256sums=('3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e'
             'c16b66c7a3825836562033e562debcc87f89d0fc117e87e94cb1f4f17eb07841'
-            'f761155f4ffdfb2660314af6e5c726179ed50a90fe9256a53a54a5d06dbdbae4'
+            'f71db9d796b6f173a6fdb4ddd08424e02085b24156018cd02063d159c9d17bb2'
             '52d7418817df4a0bd139446cf014f9dfd5bb3406a95c3109ca6fd578068be472'
             '230832038c3b8f67fdb1b284ac5f68d709cdb7f1bc752b0e60657b9b9d091045'
             '95fbe7af62b22143911bbe691a79381bf00a35c7818a5418f6ee9eade1e4a690'

--- a/zsh/PKGBUILD
+++ b/zsh/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=zsh
 pkgname=('zsh' 'zsh-doc')
 pkgver=5.3.1
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url='https://www.zsh.org/'
 license=('custom')
@@ -17,7 +17,8 @@ source=("https://downloads.sourceforge.net/project/zsh/zsh/${pkgver}/zsh-${pkgve
         add-pwd-W-option.patch
         msysize.patch
         zsh-5.0.6-1.patch
-        msys-symlink-hack.patch)
+        msys-symlink-hack.patch
+        user-autocomplete.patch)
 sha256sums=('3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e'
             'c16b66c7a3825836562033e562debcc87f89d0fc117e87e94cb1f4f17eb07841'
             'f761155f4ffdfb2660314af6e5c726179ed50a90fe9256a53a54a5d06dbdbae4'
@@ -27,7 +28,8 @@ sha256sums=('3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e'
             'b3f74a10a27eff498124adc96bc8c5cced7bb15e18c2603d7c3490a81e3c2e48'
             '4c13a4b3685b04747c48e2d3c983ec1bf01094967e39c9cabef8c9029da6e6bf'
             '336a8e6e93b778e7aec27348619b7200e0a75e5cf14dce720afd9dd6f836ea2c'
-            'de515b0d86c13c29a663b4ba0fdb338dea83f82f145cf8c4da78d30369f963e4')
+            'de515b0d86c13c29a663b4ba0fdb338dea83f82f145cf8c4da78d30369f963e4'
+            'e46c88a8853d9a4440bc3ccc1b7c161a8788ea4b8acd1bfe24b1866f48850212')
 
 prepare() {
     cd ${srcdir}/${pkgname}-${pkgver}
@@ -37,6 +39,7 @@ prepare() {
     patch -p1 -i "${srcdir}/msysize.patch"
     patch -p1 -i "${srcdir}/zsh-5.0.6-1.patch"
     patch -p1 -i "${srcdir}/msys-symlink-hack.patch"
+    patch -p1 -i "${srcdir}/user-autocomplete.patch"
 
     autoreconf -fiv
 

--- a/zsh/user-autocomplete.patch
+++ b/zsh/user-autocomplete.patch
@@ -1,0 +1,21 @@
+diff --git a/Src/utils.c b/Src/utils.c
+index b3fa3d24c..0aeb85089 100644
+--- a/Src/utils.c
++++ b/Src/utils.c
+@@ -1230,13 +1230,13 @@ adduserdir(char *s, char *t, int flags, int always)
+ 	 * named directory, since these are sometimes used for
+ 	 * special purposes.
+ 	 */
+-	nd->dir = ztrdup(t);
++	nd->dir = metafy(t, -1, META_DUP);
+     } else
+-	nd->dir = ztrduppfx(t, eptr - t);
++	nd->dir = metafy(t, eptr - t , META_DUP);
+     /* The variables PWD and OLDPWD are not to be displayed as ~PWD etc. */
+     if (!strcmp(s, "PWD") || !strcmp(s, "OLDPWD"))
+ 	nd->node.flags |= ND_NOABBREV;
+-    nameddirtab->addnode(nameddirtab, ztrdup(s), nd);
++    nameddirtab->addnode(nameddirtab, metafy(s, -1, META_DUP), nd);
+ }
+ 
+ /* Get a named directory: this function can cause a directory name *


### PR DESCRIPTION
Under windows user name can contains local characters. Without metafy sometimes we get infinite loop and segfault. 
Upstream commit https://github.com/zsh-users/zsh/commit/a11b241d4a5ec7ee1009905372cf32fb4538fbb3