### PR TITLE
pacman: Force makepkg to produce .tar files without extended attributes

### DIFF
--- a/pacman/0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch
+++ b/pacman/0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch
@@ -1,0 +1,39 @@
+From 3757cecebbf77f05742f0226c858edaad0e9654c Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Thu, 29 Jun 2017 11:54:48 +0200
+Subject: [PATCH] makepkg: avoid creating .tar files with extended attributes
+
+Extended attributes are not necessary for pacman to work. Extended
+attributes may not even be supported by the file system to which we
+extract the files.
+
+And worst of all: pacman cannot handle extended attributes, but simply
+stops extracting files when it encounters an extended attribute.
+
+This is particularly nasty when creating packages on a system configured
+to cache, say, file integrity information about .exe files in extended
+attributes, as the created packages will fail to install any .exe files.
+
+The fix is very easy: simply pass the -no-xattrs option to bsdtar.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ scripts/makepkg.sh.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/makepkg.sh.in b/scripts/makepkg.sh.in
+index 0770640..513e4f1 100644
+--- a/scripts/makepkg.sh.in
++++ b/scripts/makepkg.sh.in
+@@ -1216,7 +1216,7 @@ create_package() {
+ 	# bsdtar's gzip compression always saves the time stamp, making one
+ 	# archive created using the same command line distinct from another.
+ 	# Disable bsdtar compression and use gzip -n for now.
+-	LANG=C bsdtar -cf - "${comp_files[@]}" * |
++	LANG=C bsdtar --no-xattrs -cf - "${comp_files[@]}" * |
+ 	case "$PKGEXT" in
+ 		*tar.gz)  ${COMPRESSGZ[@]:-gzip -c -f -n} ;;
+ 		*tar.bz2) ${COMPRESSBZ2[@]:-bzip2 -c -f} ;;
+-- 
+2.13.0
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -57,7 +57,8 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0002-Add-util-msys2.-c-h-and-rebase-db-msys2.-c.patch"
         "0003-use-busybox-for-msys2-post-installs.patch"
         "0004-Link-pacman-with-static-libraries.patch"
-        "0005-Hack-gettext-libalpm-pkg-config-static-link.patch")
+        "0005-Hack-gettext-libalpm-pkg-config-static-link.patch"
+        "0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch")
 sha256sums=('8bd5f407ce8e05c4be8f1c4be4d8dcc8550ea5e494937da5220ea2c23cbb8e04'
             'SKIP'
             '6024bbf50cc92236b7b437430cb9e4180da91925cdc19a5a7910fe172931cfb6'
@@ -70,7 +71,8 @@ sha256sums=('8bd5f407ce8e05c4be8f1c4be4d8dcc8550ea5e494937da5220ea2c23cbb8e04'
             '928ed3ab09ec57dfd652112bc881b06ef0978f4dcfebb87c43822ea8ad7557a8'
             '23132552a388b238acf8bf650b5c2aa08cf3de63c647e84ad551807c4edfeb1e'
             '1ec59e4262546a4f25432a9194adadd039641f61225c71e56464dc641ae4a299'
-            '1c71c5f38a408fbc027db164730739e644047706a0ea3f8330ea1666a58e3e91')
+            '1c71c5f38a408fbc027db164730739e644047706a0ea3f8330ea1666a58e3e91'
+            '3422115a859547b25babb5181301a0e9a485d6bc5de5169c828d59fd88486952')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -80,6 +82,7 @@ prepare() {
   #git am "${srcdir}"/0003-use-busybox-for-msys2-post-installs.patch
   patch -p1 -i ${srcdir}/0004-Link-pacman-with-static-libraries.patch
   patch -p1 -i ${srcdir}/0005-Hack-gettext-libalpm-pkg-config-static-link.patch
+  patch -p1 -i ${srcdir}/0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
Extended attributes are not necessary for pacman to work. Extended
attributes may not even be supported by the file system to which we
extract the files.

And worst of all: pacman cannot handle extended attributes, but simply
stops extracting files when it encounters an extended attribute.

This is particularly nasty when creating packages on a system configured
to cache, say, file integrity information about .exe files in extended
attributes, as the created packages will fail to install any .exe files.

The fix is very easy: simply pass the -no-xattrs option to bsdtar.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>