### PR TITLE
ncurses: Add missing "links" for compatibility

### DIFF
--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=('ncurses' 'ncurses-devel')
 _basever=6.0
 _date=20170527
 pkgver=${_basever}.${_date}
-pkgrel=1
+pkgrel=2
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/ncurses/"
@@ -92,9 +92,12 @@ package_ncurses-devel() {
   rm -rf ${pkgdir}/usr/lib/terminfo
 
   cp -rf ${pkgdir}/usr/include/ncursesw ${pkgdir}/usr/include/ncurses
+  cp -f ${pkgdir}/usr/include/ncursesw/*.h ${pkgdir}/usr/include
 
   cp -f ${pkgdir}/usr/lib/libncursesw.a ${pkgdir}/usr/lib/libncurses.a
   cp -f ${pkgdir}/usr/lib/libncursesw.dll.a ${pkgdir}/usr/lib/libncurses.dll.a
+  cp -f ${pkgdir}/usr/lib/libncursesw.a ${pkgdir}/usr/lib/libcurses.a
+  cp -f ${pkgdir}/usr/lib/libncursesw.dll.a ${pkgdir}/usr/lib/libcurses.dll.a
 
   cp -f ${pkgdir}/usr/lib/libpanelw.a ${pkgdir}/usr/lib/libpanel.a
   cp -f ${pkgdir}/usr/lib/libpanelw.dll.a ${pkgdir}/usr/lib/libpanel.dll.a


### PR DESCRIPTION
Required for enabling compilation of sipp.