### PR TITLE
msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch - Update patch

### DIFF
--- a/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
+++ b/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
@@ -956,10 +956,10 @@ index d4c2701da..600129928 100644
    ts.SourceIdentifier.LowPart = 0x0103;
  
 diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
-index f8712e92d..eb62d59b2 100644
---- msys2-runtime/winsup/cygwin/syscalls.cc.orig	2017-06-10 05:12:41.468371100 -0400
-+++ msys2-runtime/winsup/cygwin/syscalls.cc	2017-06-10 08:50:45.318260400 -0400
-@@ -365,7 +365,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, A
+index 885931632..b7061116d 100644
+--- a/winsup/cygwin/syscalls.cc
++++ b/winsup/cygwin/syscalls.cc
+@@ -365,7 +365,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
    /* Create hopefully unique filename.
       Since we have to stick to the current directory on remote shares, make
       the new filename at least very unlikely to match by accident.  It starts
@@ -968,12 +968,12 @@ index f8712e92d..eb62d59b2 100644
       starting at U+dc00.  Use plain ASCII chars on filesystems not supporting
       Unicode.  The rest of the filename is the inode number in hex encoding
       and a hash of the full NT path in hex.  The combination allows to remove
-@@ -374,7 +374,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, A
+@@ -374,7 +374,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
    RtlAppendUnicodeToString (&recycler,
  			    (pc.fs_flags () & FILE_UNICODE_ON_DISK
  			     && !pc.fs_is_samba () && !pc.fs_is_netapp ())
 -			    ? L".\xdc63\xdc79\xdc67" : L".cyg");
-+                             ? L".\xdc73\xdc6d\xdc79\xdc6d" : L".msys");
++                            ? L".\xdc73\xdc6d\xdc79\xdc6d" : L".msys");
    pfii = (PFILE_INTERNAL_INFORMATION) infobuf;
    /* Note: Modern Samba versions apparently don't like buffer sizes of more
       than 65535 in some NtQueryInformationFile/NtSetInformationFile calls.

--- a/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
+++ b/msys2-runtime/0002-Rename-DLL-from-cygwin-to-msys.patch
@@ -957,9 +957,9 @@ index d4c2701da..600129928 100644
  
 diff --git a/winsup/cygwin/syscalls.cc b/winsup/cygwin/syscalls.cc
 index f8712e92d..eb62d59b2 100644
---- a/winsup/cygwin/syscalls.cc
-+++ b/winsup/cygwin/syscalls.cc
-@@ -365,7 +365,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+--- msys2-runtime/winsup/cygwin/syscalls.cc.orig	2017-06-10 05:12:41.468371100 -0400
++++ msys2-runtime/winsup/cygwin/syscalls.cc	2017-06-10 08:50:45.318260400 -0400
+@@ -365,7 +365,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, A
    /* Create hopefully unique filename.
       Since we have to stick to the current directory on remote shares, make
       the new filename at least very unlikely to match by accident.  It starts
@@ -968,12 +968,12 @@ index f8712e92d..eb62d59b2 100644
       starting at U+dc00.  Use plain ASCII chars on filesystems not supporting
       Unicode.  The rest of the filename is the inode number in hex encoding
       and a hash of the full NT path in hex.  The combination allows to remove
-@@ -374,7 +374,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, ACCESS_MASK access, ULONG flags)
+@@ -374,7 +374,7 @@ try_to_bin (path_conv &pc, HANDLE &fh, A
    RtlAppendUnicodeToString (&recycler,
  			    (pc.fs_flags () & FILE_UNICODE_ON_DISK
- 			     && !pc.fs_is_samba ())
+ 			     && !pc.fs_is_samba () && !pc.fs_is_netapp ())
 -			    ? L".\xdc63\xdc79\xdc67" : L".cyg");
-+			    ? L".\xdc73\xdc6d\xdc79\xdc6d" : L".msys");
++                             ? L".\xdc73\xdc6d\xdc79\xdc6d" : L".msys");
    pfii = (PFILE_INTERNAL_INFORMATION) infobuf;
    /* Note: Modern Samba versions apparently don't like buffer sizes of more
       than 65535 in some NtQueryInformationFile/NtSetInformationFile calls.

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
-pkgver=2.7.0
+pkgver=2.8.1
 pkgrel=1
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
@@ -48,7 +48,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0023-path.cc-Ignore-zero-length-exclusions.patch)
 sha256sums=('SKIP'
             'b1c5301bbb7a99b69ad6e5cb89f383f59d349ec7c7913060213c78d4550c7bb7'
-            'e1acc70d775bb32844d7ac471db1820433103dee2fed527f85768439d57cf730'
+            'bafc8df65d29c23014776ba19a524e403435bd8099df1c41985bc25bb901cb94'
             '1c7195fc436ed938617fd763b31aacc16ca0ccddc40a2045bf62cfe420a334f2'
             'ab588e075b0c6574d96bf06ab94e49958cb3bb8a417797d3a201e5b3d62d3dbc'
             'dceff6bee69e3294f5b18504ccaab7b0599af5d4423a2244be01ed4b85a1ac2d'
@@ -70,31 +70,53 @@ sha256sums=('SKIP'
             'a7866fd6bf627477b52112a24d5504fb75678e334c9cd283f176d5820b1dea55'
             '7afc2bac55c3db92a7f849a497113d82be7966d3e8bb4793e30ed006ef7229e0'
             '98ff1fb66a962ab2365222333acd6b148d44d47fd919971fea81f2ba4482b6f5')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
 prepare() {
   cd "${srcdir}"/msys2-runtime
-  git am --committer-date-is-author-date "${srcdir}"/0001-Add-MSYS-triplets.patch
-  git am --committer-date-is-author-date "${srcdir}"/0002-Rename-DLL-from-cygwin-to-msys.patch
-  git am --committer-date-is-author-date "${srcdir}"/0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch
-  git am --committer-date-is-author-date "${srcdir}"/0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch
-  git am --committer-date-is-author-date "${srcdir}"/0005-Move-root-to-usr.-Change-sorting-mount-points.-Do-no.patch
-  git am --committer-date-is-author-date "${srcdir}"/0006-Do-not-create-cygwin-symlinks.-Instead-use-deep-copy.patch
-  git am --committer-date-is-author-date "${srcdir}"/0007-Automatically-rewrite-TERM-msys-to-TERM-cygwin.patch
-  git am --committer-date-is-author-date "${srcdir}"/0008-Do-not-convert-environment-for-strace.patch
-  git am --committer-date-is-author-date "${srcdir}"/0009-convert-be-more-careful-to-stay-within-the-buffer.patch
-  git am --committer-date-is-author-date "${srcdir}"/0010-convert-check-safely-whether-we-could-allocate-the-b.patch
-  git am --committer-date-is-author-date "${srcdir}"/0011-convert-use-the-elegant-realloc-call.patch
-  git am --committer-date-is-author-date "${srcdir}"/0012-convert-plug-potential-memory-leak.patch
-  git am --committer-date-is-author-date "${srcdir}"/0013-convert-warn-when-we-cut-off-a-path.patch
-  git am --committer-date-is-author-date "${srcdir}"/0014-arg_heuristic-be-better-prepared-to-handle-path-list.patch
-  git am --committer-date-is-author-date "${srcdir}"/0015-Fix-converting-argument-looks-like-DVAR-str1-c-path1.patch
-  git am --committer-date-is-author-date "${srcdir}"/0016-Special-case-for-converting-root-directory-to-have-t.patch
-  git am --committer-date-is-author-date "${srcdir}"/0017-dcrt0.cc-Untangle-allow_glob-from-winshell.patch
-  git am --committer-date-is-author-date "${srcdir}"/0018-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch
-  git am --committer-date-is-author-date "${srcdir}"/0019-strace.cc-Don-t-set-MSYS-noglob.patch
-  git am --committer-date-is-author-date "${srcdir}"/0020-Add-debugging-for-build_argv.patch
-  git am --committer-date-is-author-date "${srcdir}"/0021-Add-debugging-for-strace-make_command_line.patch
-  git am --committer-date-is-author-date "${srcdir}"/0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch
-  git am --committer-date-is-author-date "${srcdir}"/0023-path.cc-Ignore-zero-length-exclusions.patch
+  del_file_exists winsup/cygwin/msys2_path_conv.cc \
+    winsup/cygwin/msys2_path_conv.h 
+ apply_patch_with_msg 0001-Add-MSYS-triplets.patch \
+  0002-Rename-DLL-from-cygwin-to-msys.patch \
+  0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch \
+  0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch \
+  0005-Move-root-to-usr.-Change-sorting-mount-points.-Do-no.patch \
+  0006-Do-not-create-cygwin-symlinks.-Instead-use-deep-copy.patch \
+  0007-Automatically-rewrite-TERM-msys-to-TERM-cygwin.patch \
+  0008-Do-not-convert-environment-for-strace.patch \
+  0009-convert-be-more-careful-to-stay-within-the-buffer.patch \
+  0010-convert-check-safely-whether-we-could-allocate-the-b.patch \
+  0011-convert-use-the-elegant-realloc-call.patch \
+  0012-convert-plug-potential-memory-leak.patch \
+  0013-convert-warn-when-we-cut-off-a-path.patch \
+  0014-arg_heuristic-be-better-prepared-to-handle-path-list.patch \
+  0015-Fix-converting-argument-looks-like-DVAR-str1-c-path1.patch \
+  0016-Special-case-for-converting-root-directory-to-have-t.patch \
+  0017-dcrt0.cc-Untangle-allow_glob-from-winshell.patch \
+  0018-dcrt0.cc-globify-Don-t-quote-literal-strings-differe.patch \
+  0019-strace.cc-Don-t-set-MSYS-noglob.patch \
+  0020-Add-debugging-for-build_argv.patch \
+  0021-Add-debugging-for-strace-make_command_line.patch \
+  0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch \
+  0023-path.cc-Ignore-zero-length-exclusions.patch
 }
 
 build() {

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
-pkgver=2.8.1
+pkgver=2.8.2
 pkgrel=1
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
@@ -48,7 +48,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0023-path.cc-Ignore-zero-length-exclusions.patch)
 sha256sums=('SKIP'
             'b1c5301bbb7a99b69ad6e5cb89f383f59d349ec7c7913060213c78d4550c7bb7'
-            'bafc8df65d29c23014776ba19a524e403435bd8099df1c41985bc25bb901cb94'
+            '2049ac99ae716f07d1e9e2874d2d3e902b19171a6c84fe582e136d68e094f47c'
             '1c7195fc436ed938617fd763b31aacc16ca0ccddc40a2045bf62cfe420a334f2'
             'ab588e075b0c6574d96bf06ab94e49958cb3bb8a417797d3a201e5b3d62d3dbc'
             'dceff6bee69e3294f5b18504ccaab7b0599af5d4423a2244be01ed4b85a1ac2d'
@@ -80,6 +80,14 @@ apply_patch_with_msg() {
   done
 }
 
+apply_git_am_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    git am --committer-date-is-author-date "${srcdir}/${_patch}"
+  done
+}
+
 del_file_exists() {
   for _fname in "$@"
   do
@@ -94,7 +102,7 @@ prepare() {
   cd "${srcdir}"/msys2-runtime
   del_file_exists winsup/cygwin/msys2_path_conv.cc \
     winsup/cygwin/msys2_path_conv.h 
- apply_patch_with_msg 0001-Add-MSYS-triplets.patch \
+ apply_git_am_with_msg 0001-Add-MSYS-triplets.patch \
   0002-Rename-DLL-from-cygwin-to-msys.patch \
   0003-Add-functionality-for-converting-UNIX-paths-in-argum.patch \
   0004-Add-functionality-for-changing-OS-name-via-MSYSTEM-e.patch \

--- a/msys2-w32api-headers/PKGBUILD
+++ b/msys2-w32api-headers/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname="msys2-w32api-headers"
-pkgver=5.0.0.4837.b33fcd03
+pkgver=5.0.0.4845.ec9f9d6a
 pkgrel=1
 pkgdesc="Win32 API headers for MSYS2 32bit toolchain"
 arch=('i686' 'x86_64')

--- a/msys2-w32api-runtime/PKGBUILD
+++ b/msys2-w32api-runtime/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname="msys2-w32api-runtime"
-pkgver=5.0.0.4837.b33fcd03
+pkgver=5.0.0.4845.ec9f9d6a
 pkgrel=1
 pkgdesc="Win32 API import libs for MSYS2 toolchain"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
msys2-runtime/PKGBUILD - Update newlib to 2.8.1
msys2-w32api-headers/PKGBUILD - Update to latest
msys2-w32api-runtime/PKGBUILD - Update to latest