### PR TITLE
ncurses and some updated version:

### DIFF
--- a/dialog/PKGBUILD
+++ b/dialog/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: David Mott <mott.david.j@gmail.com>
 
 pkgname=dialog
-pkgver=1.3_20160828
+pkgver=1.3_20170509
 pkgrel=1
 pkgdesc="A tool to display dialog boxes from shell scripts"
 arch=('i686' 'x86_64')
@@ -11,7 +11,7 @@ license=('LGPL2.1')
 makedepends=('ncurses-devel')
 depends=('ncurses')
 source=(ftp://invisible-island.net/$pkgname/$pkgname-${pkgver/_/-}.tgz)
-sha256sums=('453095abaec288bfbc1ca9faced917e17742cff1ea45ec46210071ac153562f9')
+sha256sums=('2ff1ba74c632b9d13a0d0d2c942295dd4e8909694eeeded7908a467d0bcd4756')
 
 build() {
   cd "$srcdir/$pkgname-${pkgver/_/-}"

--- a/emacs/PKGBUILD
+++ b/emacs/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ricky <rickleaf.wu@gmail.com>
 pkgname="emacs"
 pkgver=25.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (msys2)"
 url="http://www.gnu.org/software/${pkgname}/"
 license=('GPL3')
@@ -15,6 +15,7 @@ source=("http://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz"{,.sig}
 sha256sums=('59b55194c9979987c5e9f1a1a4ab5406714e80ffcfd415cc6b9222413bc073fa'
             'a2cd7f68023503731c84f127482e63bf6572788a3ecec34a9f57b3a7ef21ddbd'
             '0cb204f2cab4740d27a47a4adc7e4168d6034e86cd522605a85bbd03fb1db59d')
+validpgpkeys=('28D3BED851FDF3AB57FEF93C233587A47C207910')
 
 prepare() {
   cd "${pkgname}-${pkgver}"
@@ -43,8 +44,10 @@ build() {
 package() {
   cd "${srcdir}"/${pkgname}-${pkgver}
   make DESTDIR="${pkgdir}" install
-  rm -f "${pkgdir}/usr/bin/ctags.exe"
-  rm -f "${pkgdir}/usr/share/man/man1/ctags.1.gz"
+  mv "${pkgdir}/usr/bin/ctags.exe" \
+    "${pkgdir}/usr/bin/ctags-emacs.exe"
+  mv "${pkgdir}/usr/share/man/man1/ctags.1" \
+     "${pkgdir}/usr/share/man/man1/ctags-emacs.1"
   rm -f "${pkgdir}/usr/share/info/info.info.gz"
 
   local dir="${pkgdir}/usr/share/${pkgname}"

--- a/libedit/PKGBUILD
+++ b/libedit/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=libedit
 pkgname=('libedit' 'libedit-devel')
 pkgver=3.1
-pkgrel=20150325
+pkgrel=20170329
 pkgdesc="Libedit is an autotool- and libtoolized port of the NetBSD Editline library."
 groups=('libraries')
 arch=('i686' 'x86_64')
@@ -15,7 +15,7 @@ options=('staticlibs')
 source=(http://www.thrysoee.dk/editline/${pkgname}-${pkgrel}-${pkgver}.tar.gz
         libedit-20130712-1.src.patch
         libedit-3.0-20120311-msys2.patch)
-sha256sums=('c88a5e4af83c5f40dda8455886ac98923a9c33125699742603a88a0253fcc8c5'
+sha256sums=('91f2d90fbd2a048ff6dad7131d9a39e690fd8a8fd982a353f1333dd4017dd4be'
             'e973c43b6576fbafef69f05c3c95ee256bfb972d3622e8c87658e737415cc258'
             'd810791fc6da262ca712b1be34994ff1b6c80bde5fc4b587e22570f022c2a0c6')
 
@@ -40,6 +40,7 @@ build() {
   make
 
   make DESTDIR=${srcdir}/dest install
+  install -Dm644 COPYING ${srcdir}/dest//usr/share/licenses/libedit/LICENSE
 }
 
 package_libedit() {
@@ -48,6 +49,8 @@ package_libedit() {
   mkdir -p ${pkgdir}/usr
   cp -rf ${srcdir}/dest/usr/bin ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/share ${pkgdir}/usr/
+  rm "${pkgdir}"/usr/share/man/man3/history.3 # conflicts with readline
+  cp "${pkgdir}"/usr/share/man/man3/editline.3 "${pkgdir}"/usr/share/man/man3/el.3
 }
 
 package_libedit-devel() {

--- a/nano/PKGBUILD
+++ b/nano/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=nano
-pkgver=2.8.2
+pkgver=2.8.5
 pkgrel=1
 pkgdesc="Pico editor clone with enhancements"
 arch=('i686' 'x86_64')
@@ -20,7 +20,7 @@ source=(https://www.nano-editor.org/dist/v${pkgver%.*}/${pkgname}-${pkgver}.tar.
         2.2.4-wchar.patch
         nano-2.3.4-fix-ncurses-location.patch
         nano-2.8.0-msys2.patch)
-sha256sums=('023e8a7b38b2420d5476d7b2b4d8524d7de55c0853b4dc0b02e4a4adf7ecb9e0'
+sha256sums=('cb43bf11990b2839446229b0c21ed7abef67c2df861f250cc874553ca27d89c2'
             'SKIP'
             '60ea17cdaf6ce0dbcf7e21b592e54aa829b34d9aab95a7ad20ddce569605c3d4'
             '576d365d7e51fc0fd6268a45023de1ea14a9a4d30df9d6c7bd2188f426422bea'

--- a/ncurses/PKGBUILD
+++ b/ncurses/PKGBUILD
@@ -3,16 +3,16 @@
 pkgbase=ncurses
 pkgname=('ncurses' 'ncurses-devel')
 _basever=6.0
-_date=20170527
+_date=20170708
 pkgver=${_basever}.${_date}
-pkgrel=2
+pkgrel=1
 pkgdesc="System V Release 4.0 curses emulation library"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/ncurses/"
 license=('MIT')
 source=("${pkgbase}-${pkgver}.tar.gz"::"http://invisible-mirror.net/archives/ncurses/current/${pkgbase}-${_basever}-${_date}.tgz"
         0001-CRITICAL-fix-return-value-of-drv_CanHandle-on-unknow.patch)
-sha256sums=('d76d73347c8af1f93817a25784527ac5c63023c177a8bfc5d9c6968f76e3a229'
+sha256sums=('92f7024b9fabd0cc58fb5c25bbc6b64035750a8fb980c65b34032ec8f94209a4'
             '2cebf10a5187b88ecd36f3052768057618e8e252dfdcfa13585c5c0136046b46')
 
 prepare() {


### PR DESCRIPTION
dialog - 20170509 - Update to latest version
emacs -  2.52 - fix conflicts with ctags.  Allow ctags in package under new name
libedit - 2017050329 - Update to latest version
nano - 2.8.5 - Update to latest version
ncurses - 20170708 - Update to latest version