### PR TITLE
libarchive - 3.3.2 - Update to latest versions.  Enable bcrypt  so we…

### DIFF
--- a/libarchive/PKGBUILD
+++ b/libarchive/PKGBUILD
@@ -13,8 +13,10 @@ makedepends=('libbz2-devel' 'libiconv-devel' 'liblzma-devel' 'liblzo2-devel' 'li
 options=('!strip' 'debug' 'libtool')
 # provides=('libarchive.so')
 source=("http://libarchive.org/downloads/$pkgname-$pkgver.tar.gz"
+        'libarchive-3.3.2-bcrypt-fix.patch'
         'libarchive-3.3.1-msys2.patch')
 sha256sums=('ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce'
+            '34cca13f787493626a571bb640b62ed2193ba9c482b127ed1879819ccf3dcf2c'
             'ec1cb55dcc6d2bf5619942f887b8ea6ff80228e8ac3987d815410efa367f501d')
 
 prepare() {

--- a/libarchive/PKGBUILD
+++ b/libarchive/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=('libarchive' 'libarchive-devel' 'bsdcpio' 'bsdtar')
-pkgver=3.3.1
+pkgver=3.3.2
 pkgrel=1
 pkgdesc="library that can create and read several streaming archive formats"
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ options=('!strip' 'debug' 'libtool')
 # provides=('libarchive.so')
 source=("http://libarchive.org/downloads/$pkgname-$pkgver.tar.gz"
         'libarchive-3.3.1-msys2.patch')
-sha256sums=('29ca5bd1624ca5a007aa57e16080262ab4379dbf8797f5c52f7ea74a3b0424e7'
+sha256sums=('ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce'
             'ec1cb55dcc6d2bf5619942f887b8ea6ff80228e8ac3987d815410efa367f501d')
 
 prepare() {
@@ -22,6 +22,7 @@ prepare() {
 
   # msysize patch
   patch -Np1 -i "$srcdir/libarchive-3.3.1-msys2.patch"
+  patch -Np1 -i "$srcdir/libarchive-3.3.2-bcrypt-fix.patch"
   autoreconf -ivf
 }
 
@@ -41,7 +42,7 @@ build() {
 check() {
   cd "$pkgname-$pkgver"
 
-  #make check | true
+  make check || true
 }
 
 package_bsdcpio() {

--- a/libarchive/libarchive-3.3.2-bcrypt-fix.patch
+++ b/libarchive/libarchive-3.3.2-bcrypt-fix.patch
@@ -1,0 +1,59 @@
+--- libarchive-3.3.2/libarchive/archive_cryptor.c.orig	2017-07-14 07:42:27.977310000 -0400
++++ libarchive-3.3.2/libarchive/archive_cryptor.c	2017-07-14 07:42:17.059675800 -0400
+@@ -57,7 +57,7 @@ pbkdf2_sha1(const char *pw, size_t pw_le
+ 	return 0;
+ }
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
+ #ifdef _MSC_VER
+ #pragma comment(lib, "Bcrypt.lib")
+ #endif
+@@ -168,7 +168,7 @@ aes_ctr_release(archive_crypto_ctx *ctx)
+ 	return 0;
+ }
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
+ 
+ static int
+ aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)
+--- libarchive-3.3.2/libarchive/archive_cryptor_private.h.orig	2017-07-14 07:42:28.003312000 -0400
++++ libarchive-3.3.2/libarchive/archive_cryptor_private.h	2017-07-14 07:34:30.838942500 -0400
+@@ -63,7 +63,10 @@ typedef struct {
+ 	unsigned	encr_pos;
+ } archive_crypto_ctx;
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
++#if defined(__CYGWIN__)
++    # include <windows.h>
++#endif
+ #include <Bcrypt.h>
+ 
+ /* Common in other bcrypt implementations, but missing from VS2008. */
+--- libarchive-3.3.2/libarchive/archive_hmac.c.orig	2017-07-14 07:42:28.032321800 -0400
++++ libarchive-3.3.2/libarchive/archive_hmac.c	2017-07-14 07:34:30.848943200 -0400
+@@ -74,7 +74,7 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ct
+ 	memset(ctx, 0, sizeof(*ctx));
+ }
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
+ 
+ #ifndef BCRYPT_HASH_REUSABLE_FLAG
+ # define BCRYPT_HASH_REUSABLE_FLAG 0x00000020
+--- libarchive-3.3.2/libarchive/archive_hmac_private.h.orig	2017-07-14 07:42:28.049323000 -0400
++++ libarchive-3.3.2/libarchive/archive_hmac_private.h	2017-07-14 07:34:30.858448100 -0400
+@@ -53,7 +53,10 @@ int __libarchive_hmac_build_hack(void);
+ 
+ typedef	CCHmacContext archive_hmac_sha1_ctx;
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
++#if defined(__CYGWIN__)
++    # include <windows.h>
++#endif
+ #include <bcrypt.h>
+ 
+ typedef struct {


### PR DESCRIPTION
… can use Cryptography Next Generation.