### PR TITLE
fix crosstool-ng & crosstool-ng-git packages

### DIFF
--- a/crosstool-ng-git/0001-stat-check.patch
+++ b/crosstool-ng-git/0001-stat-check.patch
@@ -1,0 +1,11 @@
+diff -Naur crosstool-ng.orig/configure.ac crosstool-ng/configure.ac
+--- crosstool-ng.orig/configure.ac
++++ crosstool-ng/configure.ac
+@@ -240,7 +240,7 @@ AC_CACHE_CHECK([whether stat takes GNU or BSD format],
+      rm -f conftest
+      AS_IF([test "$attr_bsd" = "642"],
+        [acx_cv_stat_flavor=BSD],
+-       [test "$attr_gnu" = "642"],
++       [test "$attr_gnu" = "644"],
+        [acx_cv_stat_flavor=GNU],
+        [AC_MSG_ERROR([cannot determine stat(1) format option])])])

--- a/crosstool-ng-git/PKGBUILD
+++ b/crosstool-ng-git/PKGBUILD
@@ -3,9 +3,8 @@
 
 _realname="crosstool-ng"
 pkgname="$_realname"-git
-replaces="$_realname"
-replaces="$_realname"
-pkgver=r3354.e78251b
+replaces=("$_realname")
+pkgver=r4296.c609be17
 pkgrel=1
 pkgdesc="A cross-platform open-source toolchain system (git)"
 arch=('i686' 'x86_64')
@@ -17,9 +16,10 @@ makedepends=("autoconf" "automake-wrapper" "binutils" "bison"
              "tar" "texinfo" "wget" "xz")
 depends=("ncurses" "libintl")
 options=('staticlibs' 'strip')
-source=('crosstool-ng::git+https://github.com/crosstool-ng/crosstool-ng.git#branch=master')
-sha256sums=('SKIP')
-
+source=('crosstool-ng::git+https://github.com/crosstool-ng/crosstool-ng.git#branch=master'
+         0001-stat-check.patch)
+sha256sums=('SKIP'
+            '53a283a29972490d1ddc369aa68ef1837240a195dbcfefa6a0a24b2f848c87d3')
 pkgver() {
   cd "${srcdir}/${_realname}"
   echo "r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
@@ -27,7 +27,9 @@ pkgver() {
 
 prepare() {
   cd "${srcdir}/${_realname}"
+  patch -p1 -i patch -p1 -i "${srcdir}/0001-stat-check.patch"
   ./bootstrap
+  autoreconf -fiv
 }
 
 build() {

--- a/crosstool-ng/0005-GNU-stats-test.patch
+++ b/crosstool-ng/0005-GNU-stats-test.patch
@@ -1,0 +1,11 @@
+diff -Naur crosstool-ng-1.23.0.orig/configure.ac crosstool-ng-1.23.0/configure.ac
+--- crosstool-ng-1.23.0.orig/configure.ac	Thu Apr 13 11:43:42 2017
++++ crosstool-ng-1.23.0/configure.ac	Sun Jul 16 01:28:40 2017
+@@ -241,7 +241,7 @@
+      rm -f conftest
+      AS_IF([test "$attr_bsd" = "642"],
+        [acx_cv_stat_flavor=BSD],
+-       [test "$attr_gnu" = "642"],
++       [test "$attr_gnu" = "644"],
+        [acx_cv_stat_flavor=GNU],
+        [AC_MSG_ERROR([cannot determine stat(1) format option])])])

--- a/crosstool-ng/PKGBUILD
+++ b/crosstool-ng/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname="crosstool-ng"
 pkgver=1.23.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source toolchain system"
 arch=('i686' 'x86_64')
 url="http://www.crosstool-ng.org/"
@@ -16,11 +16,13 @@ options=('staticlibs' 'strip')
 source=("http://crosstool-ng.org/download/crosstool-ng/${pkgname}-${pkgver}.tar.xz"
         "0001-Modify-config-to-support-correct-Mingw64-Triplet-Nam.patch"
         "0002-use-wide-versions-of-libs-for-nconf.patch"
-        "0003-modify-kconfig-make-lintl.patch")
-md5sums=('a579d9a2a9eb0e8e62be4f2ed19723bc'
-         'e12040e1e2b9f30440be122e6db29c7a'
-         '874a56c50256aba4e85c7371db6ae296'
-         '319bbad48d3dc6536798baca7afb8b3c')
+        "0003-modify-kconfig-make-lintl.patch"
+        "0005-GNU-stats-test.patch")
+sha256sums=('68a43ea98ccf9cb345cb6eec494a497b224fee24c882e8c14c6713afbbe79196'
+            'a64a1caf173f9e894e7762cc0aecda0224007f6db292f2594453c4be326307fe'
+            '2e9217ebfb9460f81cab5ed01d656736a9f88dda5796a57417eb94e783ffdfbb'
+            '828a0b995520a5017346f5662abe0c69356e0d4bc88401b5a4f9e7e289a7aadb'
+            'cf1534068b550d7905fceaa95ee7ebcdd214881a0629c23a4c752837611884eb')
 noextract=(${pkgname}-${pkgver}.tar.xz)
 
 prepare() {
@@ -31,10 +33,12 @@ prepare() {
   patch -p1 -i "${srcdir}/0001-Modify-config-to-support-correct-Mingw64-Triplet-Nam.patch"
   patch -p1 -i "${srcdir}/0002-use-wide-versions-of-libs-for-nconf.patch"
   patch -p1 -i "${srcdir}/0003-modify-kconfig-make-lintl.patch"
+  patch -p1 -i "${srcdir}/0005-GNU-stats-test.patch"
 }
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
+  autoreconf -fiv
   ./configure \
     --build=${CHOST} \
     --prefix=/usr


### PR DESCRIPTION
1. Fix crosstool-ng package using the newest release
2. Fix crosstool-ng-git package built using master branch

Signed-off-by: Ilya Rakhlin <i.rakhlin@gmail.com>