### PR TITLE
odt2txt: Convert openDocuments to txt

### DIFF
--- a/odt2txt/.gitignore
+++ b/odt2txt/.gitignore
@@ -1,0 +1,2 @@
+odt2txt/
+odt2txt*.tar.gz

--- a/odt2txt/0001-Compile-for-Msys2.patch
+++ b/odt2txt/0001-Compile-for-Msys2.patch
@@ -1,0 +1,28 @@
+From c8d2dced8ce29c2bfcbc07bd302b71b43d3eafb9 Mon Sep 17 00:00:00 2001
+From: "albfan" <albertofanjul@gmail.com>
+Date: Sun, 6 Aug 2017 17:56:42 +0200
+Subject: [PATCH] Compile for Msys2
+
+---
+ Makefile | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index e4d31d9..03e9305 100644
+--- a/Makefile
++++ b/Makefile
+@@ -73,6 +73,11 @@ ifeq ($(UNAME_O),Cygwin)
+ 	LIBS += -liconv
+ 	EXT = .exe
+ endif
++ifeq ($(UNAME_O),Msys)
++	CFLAGS += -I/mingw$(ARCH)/lib/libzip/include
++	LIBS += -liconv -llibzip -lzip -lz -L/mingw$(ARCH)/lib
++	EXT = .exe
++endif
+ ifneq ($(MINGW32),)
+ 	CFLAGS += -I$(REGEX_DIR) -I$(ZLIB_DIR) -I$(ICONV_DIR)/include/ -I$(LIBZIP_DIR)/lib/
+ 	LIBS = $(REGEX_DIR)/regex.o
+-- 
+2.10.1
+

--- a/odt2txt/PKGBUILD
+++ b/odt2txt/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Alberto Fanjul <albertofanjul@gmail.com>
+
+[[ "$CARCH" == "x86_64" ]] && arch_make=64
+[[ "$CARCH" == "i686" ]] && arch_make=32
+
+pkgname=odt2txt
+pkgver=0.5
+pkgrel=2
+pkgdesc="extracts the text out of OpenDocument Texts"
+url="https://github.com/dstosberg/odt2txt/"
+license=("GPL2")
+arch=('any')
+depends=('zlib-devel' 'libiconv-devel' "mingw-w64-${CARCH}-libzip")
+makedepends=('git')
+source=("$pkgname::git://github.com/dstosberg/odt2txt.git#tag=v${pkgver}" "0001-Compile-for-Msys2.patch")
+sha256sums=('SKIP' 'c7a4860cc00b848c71c39020e881e63a2db81fa924c5baf5b08fa73b0207601f')
+
+prepare() {
+  cd "$srcdir"/$pkgname
+  patch -p1 -i "$srcdir/0001-Compile-for-Msys2.patch"
+}
+
+build() {
+  cd "$srcdir"/$pkgname
+  make ARCH=${arch_make}
+}
+
+package() {
+  cd "$srcdir"/$pkgname
+  mkdir -p "$pkgdir"/usr/bin
+  cp odt2txt.exe "$pkgdir"/usr/bin/odt2txt.exe
+  mkdir -p "$pkgdir"/usr/share/man/man1
+  cp odt2txt.1 "$pkgdir"/usr/share/man/man1/odt2txt.1
+}


### PR DESCRIPTION
Add odt2txt to use it on git-for-windows