### PR TITLE
libidn2: Fix dependency on libunistring

### DIFF
--- a/libidn2/PKGBUILD
+++ b/libidn2/PKGBUILD
@@ -3,12 +3,12 @@
 pkgbase=libidn2
 pkgname=('libidn2' 'libidn2-devel')
 pkgver=2.0.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Implementation of the Stringprep, Punycode and IDNA specifications"
 url="https://www.gnu.org/software/libidn/"
 arch=('i686' 'x86_64')
 license=('GPL3' 'LGPL')
-makedepends=('gcc' 'make' 'pkg-config' 'texinfo')
+makedepends=('gcc' 'make' 'pkg-config' 'texinfo' 'libunistring-devel')
 options=('!libtool' 'staticlibs')
 source=(https://ftp.gnu.org/gnu/libidn/${pkgname}-${pkgver}.tar.gz{,.sig}
         libidn2-2.0.4-msys2.patch)
@@ -38,7 +38,7 @@ build() {
 
 package_libidn2() {
   groups=('libraries')
-  depends=('info')
+  depends=('info' 'libunistring')
   install=libidn2.install
 
   mkdir -p ${pkgdir}/usr/bin


### PR DESCRIPTION
After upgrading msys2 today, gnupg was broken, because of a transitive dependency on libcurl -> libidn2, which depends on libunistring, but I didn't have that installed.

![image](https://user-images.githubusercontent.com/5137410/30271324-35cf6dde-9733-11e7-83cb-466f31ee2768.png)
