### PR TITLE
libnettle: fix missing dependency on libhogweed

### DIFF
--- a/nettle/PKGBUILD
+++ b/nettle/PKGBUILD
@@ -57,6 +57,7 @@ package_nettle() {
 
 package_libnettle() {
   groups=('libraries')
+  depends=('libhogweed')
 
   mkdir -p ${pkgdir}/usr/bin
   cp -rf ${srcdir}/dest/usr/bin/*nettle*.dll ${pkgdir}/usr/bin/
@@ -64,7 +65,7 @@ package_libnettle() {
 
 package_libhogweed() {
   groups=('libraries')
-  depends=('gmp' 'libnettle')
+  depends=('gmp')
 
   mkdir -p ${pkgdir}/usr/bin/
   cp -rf ${srcdir}/dest/usr/bin/*hogweed*.dll ${pkgdir}/usr/bin/


### PR DESCRIPTION
Without `libhogweed` mutt refuses to start with missing library error. 

Also, in Arch `libhogweed.so` is part of `nettle` package itself, not sure why it was decided here to split it into separate package.