### PR TITLE
gnupg: introduce GPG_ASKPASS support

### DIFF
--- a/gnupg/0001-Introduce-GPG_ASKPASS-support.patch
+++ b/gnupg/0001-Introduce-GPG_ASKPASS-support.patch
@@ -1,0 +1,253 @@
+From e85303f85596966c19b8af6d3370fe7fb107e4f1 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Fri, 15 Sep 2017 15:33:38 +0200
+Subject: [PATCH] Introduce GPG_ASKPASS support
+
+Just like OpenSSH interprets the environment variable SSH_ASKPASS as
+the path to a program to execute when the user needs to provide a pass
+phrase, this change teaches gpg to interpret the GPG_ASKPASS variable.
+
+This helps e.g. with Git for Windows, where Git GUI is started without
+any Win32 Console.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ g10/passphrase.c | 145 +++++++++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 131 insertions(+), 14 deletions(-)
+
+diff --git a/g10/passphrase.c b/g10/passphrase.c
+index 7cc9f6e..d61b2eb 100644
+--- a/g10/passphrase.c
++++ b/g10/passphrase.c
+@@ -41,6 +41,7 @@
+ #ifdef HAVE_LANGINFO_CODESET
+ #include <langinfo.h>
+ #endif
++#include <sys/wait.h>
+ 
+ #include "util.h"
+ #include "memory.h"
+@@ -59,6 +60,9 @@ static char *fd_passwd = NULL;
+ static char *next_pw = NULL;
+ static char *last_pw = NULL;
+ 
++static char askpass_prompt[16384];
++static int askpass_prompt_offset;
++
+ static void hash_passphrase( DEK *dek, char *pw, STRING2KEY *s2k, int create );
+ 
+ int
+@@ -687,6 +691,100 @@ agent_get_passphrase ( u32 *keyid, int mode, const char *cacheid,
+ }
+ 
+ 
++/**
++ * Call the askpass helper defined by GPG_ASKPASS.
++ */
++static char *
++read_passphrase_from_askpass( const char *askpass )
++{
++  char *pw = NULL;
++  int fd[2];
++  pid_t pid;
++
++  if (pipe(fd) < 0)
++    log_error("askpass: pipe: %s", strerror(errno));
++  else if ((pid = fork()) < 0)
++    log_error("askpass: fork: %s", strerror(errno));
++  else if (!pid)
++  {
++    close(fd[0]);
++    if (dup2(fd[1], 1) < 0)
++      log_error("askpass: dup2: %s", strerror(errno));
++    else
++    {
++      log_info("prompt: %s", askpass_prompt);
++      execlp(askpass, askpass, askpass_prompt, NULL);
++      log_error("askpass: execlp: %s", strerror(errno));
++    }
++    exit(1);
++  }
++  else
++  {
++    char buffer[1024];
++    ssize_t count, pw_len = 0;
++    int exit_code;
++
++    close(fd[1]);
++    for (;;)
++    {
++      count = read(fd[0], buffer, DIM(buffer));
++      if (!count)
++        break;
++      if (count > 0)
++      {
++        pw = realloc(pw, pw_len + count + 1);
++        memcpy(pw + pw_len, buffer, count);
++        pw_len += count;
++        pw[pw_len] = '\0';
++      }
++      else if (errno != EINTR)
++      {
++        log_error("askpass: read: %s", strerror(errno));
++        free(pw);
++        pw_len = 0;
++        pw = NULL;
++        break;
++      }
++      if (pw_len && pw[pw_len - 1] == '\n')
++        pw[--pw_len] = '\0';
++      if (pw_len && pw[pw_len - 1] == '\r')
++        pw[--pw_len] = '\0';
++    }
++    close(fd[0]);
++
++    while (waitpid(pid, &exit_code, 0) < 0)
++      if (errno != EINTR)
++      {
++        log_error("askpass: waitpid: %s", strerror(errno));
++        exit_code = 0; /* avoid bogus exit code */
++        break;
++      }
++
++    if (exit_code)
++    {
++      log_error("askpass '%s' exited with %d", askpass, exit_code);
++      free(pw);
++      pw = NULL;
++    }
++  }
++
++  return pw;
++}
++
++#define TTY_PRINTF(...) \
++  { \
++    if (askpass) \
++      { \
++        askpass_prompt_offset += \
++          snprintf (askpass_prompt + askpass_prompt_offset, \
++            DIM(askpass_prompt) - 1 - askpass_prompt_offset, __VA_ARGS__); \
++        if (askpass_prompt_offset > DIM(askpass_prompt) - 1) \
++          askpass_prompt_offset = DIM(askpass_prompt) - 1; \
++      } \
++    else \
++      tty_printf (__VA_ARGS__); \
++  }
++
+ /*
+  * Clear the cached passphrase.  If CACHEID is not NULL, it will be
+  * used instead of a cache ID derived from KEYID.
+@@ -775,6 +873,10 @@ ask_passphrase (const char *description,
+                 const char *cacheid, int *canceled)
+ {
+   char *pw = NULL;
++  char *askpass = getenv("GPG_ASKPASS");
++
++  askpass_prompt_offset = 0;
++  askpass_prompt[0] = '\0';
+ 
+   if (canceled)
+     *canceled = 0;
+@@ -784,11 +886,11 @@ ask_passphrase (const char *description,
+       if (strchr (description, '%'))
+         {
+           char *tmp = unescape_percent_string (description);
+-          tty_printf ("\n%s\n", tmp);
++          TTY_PRINTF ("\n%s\n", tmp);
+           xfree (tmp);
+         }
+       else
+-        tty_printf ("\n%s\n",description);
++        TTY_PRINTF ("\n%s\n",description);
+     }
+ 
+  agent_died:
+@@ -816,9 +918,13 @@ ask_passphrase (const char *description,
+     }
+   else {
+     if (tryagain_text)
+-      tty_printf(_("%s.\n"), tryagain_text);
+-    pw = cpr_get_hidden(promptid? promptid : "passphrase.ask",
+-                        prompt?prompt : _("Enter passphrase: ") );
++      TTY_PRINTF(_("%s.\n"), tryagain_text);
++    if (askpass) {
++      if (!(pw = read_passphrase_from_askpass(askpass)) && canceled)
++	*canceled = 1;
++    } else
++      pw = cpr_get_hidden(promptid? promptid : "passphrase.ask",
++                          prompt?prompt : _("Enter passphrase: ") );
+     tty_kill_prompt();
+   }
+ 
+@@ -844,6 +950,10 @@ passphrase_to_dek( u32 *keyid, int pubkey_algo,
+     char *pw = NULL;
+     DEK *dek;
+     STRING2KEY help_s2k;
++    char *askpass = getenv("GPG_ASKPASS");
++
++    askpass_prompt_offset = 0;
++    askpass_prompt[0] = '\0';
+ 
+     if (canceled)
+       *canceled = 0;
+@@ -900,14 +1010,14 @@ passphrase_to_dek( u32 *keyid, int pubkey_algo,
+ 	char *p;
+ 
+ 	p=get_user_id_native(keyid);
+-	tty_printf("\n");
+-	tty_printf(_("You need a passphrase to unlock the secret key for\n"
++	TTY_PRINTF("\n");
++	TTY_PRINTF(_("You need a passphrase to unlock the secret key for\n"
+ 		     "user: \"%s\"\n"),p);
+ 	xfree(p);
+ 
+ 	if( !get_pubkey( pk, keyid ) ) {
+ 	    const char *s = pubkey_algo_to_string( pk->pubkey_algo );
+-	    tty_printf( _("%u-bit %s key, ID %s, created %s"),
++	    TTY_PRINTF( _("%u-bit %s key, ID %s, created %s"),
+ 		       nbits_from_pk( pk ), s?s:"?", keystr(keyid),
+ 		       strtimestamp(pk->timestamp) );
+ 	    if( keyid[2] && keyid[3] && keyid[0] != keyid[2]
+@@ -915,17 +1025,17 @@ passphrase_to_dek( u32 *keyid, int pubkey_algo,
+ 	      {
+ 		if(keystrlen()>10)
+ 		  {
+-		    tty_printf("\n");
+-		    tty_printf(_("         (subkey on main key ID %s)"),
++		    TTY_PRINTF("\n");
++		    TTY_PRINTF(_("         (subkey on main key ID %s)"),
+ 			       keystr(&keyid[2]) );
+ 		  }
+ 		else
+-		  tty_printf( _(" (main key ID %s)"), keystr(&keyid[2]) );
++		  TTY_PRINTF( _(" (main key ID %s)"), keystr(&keyid[2]) );
+ 	      }
+-	    tty_printf("\n");
++	    TTY_PRINTF("\n");
+ 	}
+ 
+-	tty_printf("\n");
++	TTY_PRINTF("\n");
+         if (pk)
+           free_public_key( pk );
+     }
+@@ -985,7 +1095,14 @@ passphrase_to_dek( u32 *keyid, int pubkey_algo,
+       }
+     else {
+         /* Read the passphrase from the tty or the command-fd. */
+-	pw = cpr_get_hidden("passphrase.enter", _("Enter passphrase: ") );
++	if (askpass) {
++	    if (!(pw = read_passphrase_from_askpass(askpass))) {
++	        if (canceled)
++		    *canceled = 1;
++	        return NULL;
++	    }
++	} else
++	    pw = cpr_get_hidden("passphrase.enter", _("Enter passphrase: ") );
+ 	tty_kill_prompt();
+ 	if( mode == 2 && !cpr_enabled() )
+ 	  {
+-- 
+2.14.1.windows.1.510.g0cb6d35d23
+

--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gnupg
 pkgver=1.4.22
-pkgrel=1
+pkgrel=2
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 url='https://gnupg.org/'
 license=('GPL')
@@ -36,16 +36,19 @@ depends=('bzip2'
          'zlib'
         )
 source=("https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
-        'gnupg-1.4.20-msys2.patch')
+        'gnupg-1.4.20-msys2.patch'
+	'0001-Introduce-GPG_ASKPASS-support.patch')
 sha256sums=('9594a24bec63a21568424242e3f198b9d9828dea5ff0c335e47b06f835f930b4'
             'SKIP'
-            '37dc00f02d5cb04880e8dc286e80ea2a000b7357002a44cdbebe495d43fa5980')
+            '37dc00f02d5cb04880e8dc286e80ea2a000b7357002a44cdbebe495d43fa5980'
+            '3e6cfc7916aa2057374f0b455ce59ba82d08fafc34e3ab06688acf52f927acf0')
 
 install=${pkgname}.install
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/gnupg-1.4.20-msys2.patch
+  patch -p1 -i ${srcdir}/0001-Introduce-GPG_ASKPASS-support.patch
 
   ./autogen.sh
 }


### PR DESCRIPTION
It is all fine and dandy when users GPG-sign files from the terminal.
But when they do not, things get more complicated.

The usual thing is to install a pinentry helper targeting your graphical
desktop and then launching the GPG agent somehow and connet it all
together.

Except that MSYS2 does not come with a gpg-agent.

So let's just imitate openssh, which interprets the environment variable
SSH_ASKPASS (if set) as the path to a helper that can be called upon to
ask the user to provide a passphrase.

Unsurprisingly, the new environment variable is called GPG_ASKPASS (and
we do not repeat Git's mistake of co-opting SSH_ASKPASS, if set).

This allows, say, Git for Windows' Git GUI to commit with GPG signatures
even if the passphrase is not empty.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>