### PR TITLE
Add new package; winln

### DIFF
--- a/winln/PKGBUILD
+++ b/winln/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Ilya Rakhlin <irakhlin@gmail.com>
+
+pkgname=winln
+pkgver=1.1
+pkgrel=1
+pkgdesc="Create windows symlinks from inside msys2 shell"
+arch=('i686' 'x86_64')
+url="https://github.com/irakhlin/winln"
+license=('GPL')
+source=("https://github.com/irakhlin/winln/releases/download/1.1/winln-1.1.tar.bz2")
+sha256sums=('84f9797c3a2054cab00336b3c27bf1e7f9d8625974d34339fc317ca806efb700')
+
+build() {
+  cd "$srcdir/${pkgname}-${pkgver}"
+  ./configure --prefix=/usr
+  make
+}
+
+package() {
+  cd "$srcdir/${pkgname}-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
1. Add package winln using code from a similar package in cygwin. It follows the same commands as ln, only uses native windows API to create actual symlinks. This may be useful to alot of requests I have seen before to create symlinks in msys2..