### PR TITLE
libunistring: package static lib; fixes pacman build

### DIFF
--- a/libunistring/PKGBUILD
+++ b/libunistring/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('libunistring' 'libunistring-devel')
 pkgver=0.9.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for manipulating Unicode strings and C strings."
 url="https://www.gnu.org/software/libunistring/"
 arch=('i686' 'x86_64')
@@ -45,7 +45,7 @@ package_libunistring() {
 package_libunistring-devel() {
   pkgdesc="libunistring headers and libraries"
   groups=('development')
-  options=('!staticlibs')
+  options=('staticlibs')
   depends=("libunistring=${pkgver}" "libiconv-devel")
 
   mkdir -p ${pkgdir}/usr


### PR DESCRIPTION
unistring gets pulled in through curl but was missing a static build.