### PR TITLE
pacman/libalpm: ignore file conflicts for foo.exe -> foo renames

### DIFF
--- a/pacman/0007-exe-interp-ignore-file-conflict.patch
+++ b/pacman/0007-exe-interp-ignore-file-conflict.patch
@@ -1,0 +1,35 @@
+--- pacman-5.0.1/lib/libalpm/conflict.c.orig	2016-01-04 04:27:45.000000000 +0100
++++ pacman-5.0.1/lib/libalpm/conflict.c	2017-09-27 15:11:44.461428600 +0200
+@@ -514,6 +514,32 @@
+ 
+ 			_alpm_log(handle, ALPM_LOG_DEBUG, "checking possible conflict: %s\n", path);
+ 
++#ifdef __MSYS__
++			/* In case a file "foo.exe" gets renamed to "foo" the msys2 .exe
++			 * interpolation makes pacman think an untracker file is replaced.
++			 * In case foo and foo.exe are the same file and foo.exe existed
++			 * in the old package version we can be sure it's handled by the
++			 * old package and ignore the conflict */
++			if(dbpkg) {
++				char path_exe[PATH_MAX];
++				struct stat lsbuf2;
++
++				strncpy(path_exe, path, sizeof(path_exe) - 4);
++				strcat(path_exe, ".exe");
++				if(llstat(path, &lsbuf) == 0 && llstat(path_exe, &lsbuf2) == 0) {
++					int old_contains_exe = (alpm_filelist_contains(alpm_pkg_get_files(dbpkg), path_exe + rootlen) != NULL);
++					int same_file = (lsbuf.st_dev == lsbuf2.st_dev && lsbuf.st_ino == lsbuf2.st_ino);
++
++					if(same_file && old_contains_exe) {
++						_alpm_log(handle, ALPM_LOG_DEBUG,
++								"MSYS2 special case: Found %s which is the same file and included in the old package\n",
++								path_exe);
++						continue;
++					}
++				}
++			}
++#endif
++
+ 			if(path[pathlen - 1] == '/') {
+ 				if(S_ISDIR(lsbuf.st_mode)) {
+ 					_alpm_log(handle, ALPM_LOG_DEBUG, "file is a directory, not a conflict\n");

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.0.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -58,7 +58,8 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0003-use-busybox-for-msys2-post-installs.patch"
         "0004-Link-pacman-with-static-libraries.patch"
         "0005-Hack-gettext-libalpm-pkg-config-static-link.patch"
-        "0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch")
+        "0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch"
+        "0007-exe-interp-ignore-file-conflict.patch")
 sha256sums=('8bd5f407ce8e05c4be8f1c4be4d8dcc8550ea5e494937da5220ea2c23cbb8e04'
             'SKIP'
             '6024bbf50cc92236b7b437430cb9e4180da91925cdc19a5a7910fe172931cfb6'
@@ -72,7 +73,8 @@ sha256sums=('8bd5f407ce8e05c4be8f1c4be4d8dcc8550ea5e494937da5220ea2c23cbb8e04'
             '23132552a388b238acf8bf650b5c2aa08cf3de63c647e84ad551807c4edfeb1e'
             '1ec59e4262546a4f25432a9194adadd039641f61225c71e56464dc641ae4a299'
             '1c71c5f38a408fbc027db164730739e644047706a0ea3f8330ea1666a58e3e91'
-            '3422115a859547b25babb5181301a0e9a485d6bc5de5169c828d59fd88486952')
+            '3422115a859547b25babb5181301a0e9a485d6bc5de5169c828d59fd88486952'
+            'a88d4531283d5b85cde5793c8867bb554fdac7513f948f172c0d64ea0ca544f9')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -83,6 +85,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0004-Link-pacman-with-static-libraries.patch
   patch -p1 -i ${srcdir}/0005-Hack-gettext-libalpm-pkg-config-static-link.patch
   patch -p1 -i ${srcdir}/0006-makepkg-avoid-creating-.tar-files-with-extended-attr.patch
+  patch -p1 -i ${srcdir}/0007-exe-interp-ignore-file-conflict.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
In case a file "foo.exe" gets renamed to "foo" the msys2 .exe
interpolation makes pacman think an untracker file is replaced.
In case foo and foo.exe are the same file and foo.exe existed
in the old package version we can be sure it's handled by the
old package and ignore the conflict.