### PR TITLE
coreutils: fix libstdbuf.so.exe problem once and for all

### DIFF
--- a/coreutils/PKGBUILD
+++ b/coreutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=coreutils
 pkgver=8.26
-pkgrel=1
+pkgrel=2
 pkgdesc="The basic file, shell and text manipulation utilities of the GNU operating system"
 arch=('i686' 'x86_64')
 license=('GPL3')
@@ -60,6 +60,10 @@ build() {
 package() {
   cd ${srcdir}/build-${CHOST}
   make DESTDIR=${pkgdir} install
+
+  test ! -f ${pkgdir}/usr/lib/coreutils/libstdbuf.so.exe ||
+  mv ${pkgdir}/usr/lib/coreutils/libstdbuf.so.exe \
+    ${pkgdir}/usr/lib/coreutils/libstdbuf.so
 
   #mkdir -p ${pkgdir}/usr/etc
   install -Dm644 ${srcdir}/${pkgname}-${pkgver}/src/dircolors.hin ${pkgdir}/etc/DIR_COLORS


### PR DESCRIPTION
The `stdbuf.exe` program links to a `libstdbuf.so` file, so if that does
not exist, there is a problem.

In d9773f0a (coreutils: Update to 8.24, 2015-08-28), a sed call was
introduced to ensure that `libstdbuf.so` is built and installed under
that name, without `.exe` suffix.

As reported in https://github.com/Alexpux/MSYS2-packages/issues/541,
however, that fix no longer works, the `libstdbuf.so.exe` file is in
coreutils 8.26-1.

Let's just rename the `libstdbuf.so.exe` file after it has been
installed into the `pkgdir` tree.

Note: we still have to muck around with `Makefile.in` so that the build
does not break with

	make[2]: *** No rule to make target 'src/libstdbuf.so', needed
	by 'all-am'.  Stop.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>