### PR TITLE
Bump icu dependency requirements to the newest version.

### DIFF
--- a/libpsl/PKGBUILD
+++ b/libpsl/PKGBUILD
@@ -3,13 +3,13 @@
 pkgbase='libpsl'
 pkgname=("${pkgbase}" "${pkgbase}-devel")
 pkgver=0.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Public Suffix List library'
 url='https://github.com/rockdaboot/libpsl'
 arch=('i686' 'x86_64')
 license=('MIT')
-depends=('icu>=55.1-1')
-makedepends=('libxslt' 'python3' 'publicsuffix-list')
+depends=('icu>=59.1')
+makedepends=('libxslt' 'python3' 'icu-devel' 'publicsuffix-list')
 source=(https://github.com/rockdaboot/libpsl/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.gz
         0001-win32-fix.patch
         0.16.0-no-undefined.patch
@@ -84,7 +84,7 @@ check() {
 
 package_libpsl() {
  pkgdesc="Public Suffix List library (runtime)"
-  depends=('libxslt' 'icu>=55.1-1')
+  depends=('libxslt' 'icu>=59.1')
   groups=('libraries')
 
   mkdir -p ${pkgdir}/usr/bin
@@ -98,7 +98,7 @@ package_libpsl() {
 package_libpsl-devel() {
   pkgdesc="libpsl headers and libraries"
   options=('staticlibs')
-  depends=("libpsl=${pkgver}" 'libxslt' 'icu>=55.1-1')
+  depends=("libpsl=${pkgver}" 'libxslt' 'icu>=59.1')
   groups=('development')
 
   mkdir -p ${pkgdir}/usr/share/man/man3

--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -6,12 +6,12 @@ pkgname=('sqlite' 'libsqlite' 'libsqlite-devel' 'sqlite-doc')
 _amalgamationver=3190300
 _docver=${_amalgamationver}
 pkgver=3.19.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A C library that implements an SQL database engine"
 arch=('i686' 'x86_64')
 license=(PublicDomain)
 url="https://www.sqlite.org/"
-depends=('libreadline' 'icu' 'zlib')
+depends=('libreadline' 'icu>=59.1' 'zlib')
 makedepends=('libreadline-devel' 'icu-devel' 'zlib-devel')
 source=( # tarball containing the amalgamation for SQLite >= 3.7.5 together with a configure script and makefile for building it; includes now also the Tcl Extension Architecture (TEA)
         https://www.sqlite.org/2017/sqlite-autoconf-${_amalgamationver}.tar.gz


### PR DESCRIPTION
It was reported on IRC that installing wget on appveyor wont
update icu which results in icu not being found due to an ABI bump/dll rename.
Bumping the version requirements of icu users should fix this.