### PR TITLE
mintty: Install language files

### DIFF
--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=mintty
 pkgver=2.7.9
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
 arch=('i686' 'x86_64')
@@ -43,6 +43,7 @@ package() {
   mkdir -p ${pkgdir}/usr/{bin,share}
   mkdir -p ${pkgdir}/usr/share/man/man1
   mkdir -p ${pkgdir}/usr/share/licenses/${pkgname}
+  mkdir -p ${pkgdir}/usr/share/${pkgname}/lang
 
   install -m755 bin/mintty.exe ${pkgdir}/usr/bin/mintty.exe
   install -m644 docs/mintty.1 ${pkgdir}/usr/share/man/man1/mintty.1
@@ -50,4 +51,7 @@ package() {
   install -m644 LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/
   install -m644 LICENSE.Oxygen ${pkgdir}/usr/share/licenses/${pkgname}/
   install -m644 LICENSE.PuTTY ${pkgdir}/usr/share/licenses/${pkgname}/
+
+  install -m644 lang/messages.pot ${pkgdir}/usr/share/${pkgname}/lang/
+  install -m644 lang/*.po ${pkgdir}/usr/share/${pkgname}/lang/
 }


### PR DESCRIPTION
Recent version of mintty has localized messages, but they were not installed.
Install them.