### PR TITLE
Update `vim` to v8.0.1213

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=vim
 _topver=8.0
-_patchlevel=0606
+_patchlevel=1216
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -20,7 +20,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('fe8dc50c735f625073cbe06b6dda863e623117ce41b66f40ce5f7efd77a1109e'
+sha256sums=('da080b8d32fa2033517e71389cb4a036970b01607b35b55cc6fe4bc7c92f6d8f'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'

--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=vim
 _topver=8.0
-_patchlevel=1216
+_patchlevel=1213
 _versiondir="${pkgname}${_topver//./}"
 pkgver=${_topver}.${_patchlevel}
 pkgrel=1
@@ -20,7 +20,7 @@ source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgve
         'pretend-cygwin-msys.patch'
         'accept-crlf.patch'
         'vim-completion')
-sha256sums=('da080b8d32fa2033517e71389cb4a036970b01607b35b55cc6fe4bc7c92f6d8f'
+sha256sums=('2198340b317fed9a309ae983f4bd501a93852023754dd891bcda81a2ec5298e0'
             'edd18e0756406ee7b659e4552e444c50c3a0c1e9fb4fce2ddd770c933ea6c7f5'
             'bca6e030d50c0d2468ab5c78aa0b359eb18a88a197de8406c593458ffedde922'
             '44d7738a8f801195898eeef766ff77506c717dd5d19145ade3c1c2349d4bc4fd'


### PR DESCRIPTION
I've done a very basic smoke test opening `vim` and ensuring that there's no issues loading up my rather large [`vimrc`](https://github.com/erichdongubler-dotfiles/vim/blob/0b53811fe036dedce79be64f74ce466ba31f620d/.config/vim/vimrc). If you'd prefer the community did some more testing, I'm more than happy to help make that happen. :)

The main feature of this update is the addition of the `CmdlineLeave` and `CmdlineEnter` `autocmd` triggers.