### PR TITLE
Add autoconf to vim's build dependencies

### DIFF
--- a/vim/PKGBUILD
+++ b/vim/PKGBUILD
@@ -11,7 +11,7 @@ license=('custom:vim')
 url="http://www.vim.org"
 depends=('ncurses')
 groups=('editors')
-makedepends=('gawk' 'perl' 'python2' 'python3' 'ruby' 'libiconv' 'ncurses-devel' 'libcrypt-devel')
+makedepends=('autoconf' 'gawk' 'perl' 'python2' 'python3' 'ruby' 'libiconv' 'ncurses-devel' 'libcrypt-devel')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/vim/vim/archive/v${pkgver}.tar.gz
         'dot.vimrc'
         '7.3-cygwin-mouse.patch'


### PR DESCRIPTION
While creating a [PR updating `vim`](https://github.com/Alexpux/MSYS2-packages/pull/1049), I noticed that `autoconf` wasn't specified as a build dependency and caused my build to fail -- I've added it to the `PKGBUILD` build dependencies.

I don't know of other missing dependencies, but I hope that this PR will help others who maintain the `vim` `PKGBUILD` down the road. :)