### PR TITLE
Upgrade mintty to 2.8.0

### DIFF
--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=mintty
-pkgver=2.7.9
+pkgver=2.8.0
 pkgrel=1
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
@@ -13,7 +13,7 @@ url="https://mintty.github.io"
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
         0002-add-msys2-launcher.patch
         0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch)
-sha256sums=('62b552ba6da27a9a120c47e88262e4f6c2724daae172c7647d1cc76f47cb9ed3'
+sha256sums=('fc09bb42d844fc92e72f839c07805ed0b8189fffed4580528282f8163a0f74d8'
             '2206240168fa481e54346406e96820a1e0a678a9cc21076bd8fac4c97c527dd4'
             'd2398c8586c8eaa04dc2f49d663855f420a17feec918f6ac63a8b975037cd86c')
 


### PR DESCRIPTION
https://github.com/mintty/mintty/releases/tag/2.8.0