### PR TITLE
Add cpio package (version 2.12)

### DIFF
--- a/cpio/PKGBUILD
+++ b/cpio/PKGBUILD
@@ -1,0 +1,30 @@
+pkgname=cpio
+pkgver=2.12
+pkgrel=1
+pkgdesc="A tool to copy files into or out of a cpio or tar archive"
+arch=('i686' 'x86_64')
+url="https://www.gnu.org/software/cpio/"
+license=('GPLv3')
+depends=('libintl' 'libiconv')
+makedepends=('gettext-devel')
+options=('staticlibs')
+source=(http://ftp.gnu.org/pub/gnu/cpio/cpio-2.12.tar.gz)
+sha256sums=('08a35e92deb3c85d269a0059a27d4140a9667a6369459299d08c17f713a92e73')
+
+build() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+
+  ./configure --prefix=/usr
+
+  make
+}
+
+package() {
+  cd ${srcdir}/${pkgname}-${pkgver}
+
+  make DESTDIR=${pkgdir} install
+
+  # remove rmt
+  rm -rf ${pkgdir}/usr/libexec
+  rm -rf ${pkgdir}/usr/share/man/man8
+}

--- a/cpio/PKGBUILD
+++ b/cpio/PKGBUILD
@@ -1,3 +1,5 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
 pkgname=cpio
 pkgver=2.12
 pkgrel=1


### PR DESCRIPTION
This adds the cpio (GNU) package (version 2.12).

I know that this will be marked as a duplicate, due to another user already having submitted cpio to MSYS2-packages. However, he did not add himself as a maintainer to the package, and has not responded in a long time. This pull request fixes the issue.