### PR TITLE
Add plotutils (version 2.6) (WIP)

### DIFF
--- a/plotutils/PKGBUILD
+++ b/plotutils/PKGBUILD
@@ -5,24 +5,28 @@ arch=('x86_64' 'i686')
 pkgdesc="Set of utilities and libraries for plotting."
 url="http://directory.fsf.org/graphics/plotutils.html"
 license=("GPL")
+makedepends=("libpng-devel")
 depends=("libpng" "gcc-libs")
 source=(http://ftp.gnu.org/pub/gnu/plotutils/$pkgname-$pkgver.tar.gz
         plotutils-2.6-libpng-1.5.patch
-        plotutils-2.6-fix-autoreconf-error.patch)
+        plotutils-2.6-fix-autoreconf-error.patch
+        plotutils-2.6-fix-undefined-linking.patch)
 sha1sums=('7921301d9dfe8991e3df2829bd733df6b2a70838'
           '492f0e04f8265ab50d9ba0905a0f5adf3ec06ab8'
-          'fc0a0eccc1007093d16ea7c631f764b9b4cabb16')
+          'fc0a0eccc1007093d16ea7c631f764b9b4cabb16'
+          'a672f3c4c88fb6bf64b946979b51fe3ff417cd05')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -Np0 -i ${srcdir}/plotutils-2.6-libpng-1.5.patch
   patch -Np1 -i ${srcdir}/plotutils-2.6-fix-autoreconf-error.patch
+  patch -Np1 -i ${srcdir}/plotutils-2.6-fix-undefined-linking.patch
   autoreconf -fiv
 }
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
-  ./configure --prefix=/usr \
+    ./configure --prefix=/usr \
 	--with-gnu-ld \
 	--enable-libplotter
   make

--- a/plotutils/PKGBUILD
+++ b/plotutils/PKGBUILD
@@ -1,0 +1,34 @@
+pkgname=plotutils
+pkgver=2.6
+pkgrel=1
+arch=('x86_64' 'i686')
+pkgdesc="Set of utilities and libraries for plotting."
+url="http://directory.fsf.org/graphics/plotutils.html"
+license=("GPL")
+depends=("libpng" "gcc-libs")
+source=(http://ftp.gnu.org/pub/gnu/plotutils/$pkgname-$pkgver.tar.gz
+        plotutils-2.6-libpng-1.5.patch
+        plotutils-2.6-fix-autoreconf-error.patch)
+sha1sums=('7921301d9dfe8991e3df2829bd733df6b2a70838'
+          '492f0e04f8265ab50d9ba0905a0f5adf3ec06ab8'
+          'fc0a0eccc1007093d16ea7c631f764b9b4cabb16')
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  patch -Np0 -i ${srcdir}/plotutils-2.6-libpng-1.5.patch
+  patch -Np1 -i ${srcdir}/plotutils-2.6-fix-autoreconf-error.patch
+  autoreconf -fiv
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  ./configure --prefix=/usr \
+	--with-gnu-ld \
+	--enable-libplotter
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make DESTDIR="${pkgdir}" install
+}

--- a/plotutils/PKGBUILD
+++ b/plotutils/PKGBUILD
@@ -1,3 +1,5 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
 pkgname=plotutils
 pkgver=2.6
 pkgrel=1

--- a/plotutils/plotutils-2.6-fix-autoreconf-error.patch
+++ b/plotutils/plotutils-2.6-fix-autoreconf-error.patch
@@ -1,0 +1,11 @@
+--- plotutils-2.6/configure-orig.ac	2017-11-07 08:15:10.607494500 -0500
++++ plotutils-2.6/configure.ac	2017-11-07 08:15:59.980212900 -0500
+@@ -3,6 +3,8 @@
+ # Process this file with autoconf to produce a configure script.
+ 
+ AC_INIT([GNU plotutils],[2.6],[bug-plotutils@gnu.org])
++AC_PROG_CXX
++AC_PROG_CC
+ AC_PREREQ(2.59)
+ AC_CONFIG_SRCDIR(graph/graph.c)
+ AM_INIT_AUTOMAKE([plotutils],[2.6])

--- a/plotutils/plotutils-2.6-fix-undefined-linking.patch
+++ b/plotutils/plotutils-2.6-fix-undefined-linking.patch
@@ -1,0 +1,25 @@
+unchanged:
+--- plotutils-2.6/libplotter/Makefile-orig.am	2017-11-07 12:37:12.864600600 -0500
++++ plotutils-2.6/libplotter/Makefile.am	2017-11-07 12:37:15.106167000 -0500
+@@ -2,7 +2,7 @@
+ 
+ lib_LTLIBRARIES = libplotter.la
+ 
+-libplotter_la_LDFLAGS = -version-info 4:4:2
++libplotter_la_LDFLAGS = -no-undefined -version-info 4:4:2
+ 
+ INCLUDES = $(X_CFLAGS) -I$(srcdir)/../include -DLIBPLOT -DLIBPLOTTER
+ 
+only in patch2:
+unchanged:
+--- plotutils-2.6/libplot/Makefile-orig.am	2017-11-07 12:36:48.597127000 -0500
++++ plotutils-2.6/libplot/Makefile.am	2017-11-07 12:36:50.054730000 -0500
+@@ -4,7 +4,7 @@
+ 
+ EXTRA_DIST = DEDICATION HUMOR README-cgm README-gif README-hpgl README-tek VERSION
+ 
+-libplot_la_LDFLAGS = -version-info 4:4:2
++libplot_la_LDFLAGS = -no-undefined -version-info 4:4:2
+ 
+ INCLUDES = $(X_CFLAGS) -I$(srcdir)/../include -DLIBPLOT
+ 

--- a/plotutils/plotutils-2.6-libpng-1.5.patch
+++ b/plotutils/plotutils-2.6-libpng-1.5.patch
@@ -1,0 +1,31 @@
+fix building with libpng-1.5
+
+--- libplot/z_write.c
++++ libplot/z_write.c
+@@ -164,7 +164,7 @@
+     }
+ 
+   /* cleanup after libpng errors (error handler does a longjmp) */
+-  if (setjmp (png_ptr->jmpbuf))
++  if (setjmp (png_jmpbuf (png_ptr)))
+     {
+       png_destroy_write_struct (&png_ptr, (png_info **)NULL);
+       return -1;
+@@ -444,7 +444,7 @@
+ #endif
+     }
+ 
+-  longjmp (png_ptr->jmpbuf, 1);
++  png_longjmp (png_ptr, 1);
+ }
+ 
+ static void 
+@@ -515,7 +515,7 @@
+ #endif
+     }
+ 
+-  longjmp (png_ptr->jmpbuf, 1);
++  png_longjmp (png_ptr, 1);
+ }
+ 
+ static void 


### PR DESCRIPTION
This adds the plotutils package.

There seems to be something wrong with /usr/bin/graph.exe. Using ldd
reveals a double-dependency for msys-2.0.dll. Executing graph.exe causes
it to crash. Any feedback welcome.