### PR TITLE
Added xorriso package

### DIFF
--- a/xorriso/PKGBUILD
+++ b/xorriso/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Michael R. Taylor <michael@atomic.city>
+
+pkgname=xorriso
+pkgver=1.4.8
+pkgrel=1
+pkgdesc="xorriso copies files from POSIX filesystems into Rock Ridge enhanced ISO 9660 filesystems and allows manipulation of such filesystems."
+arch=('i686' 'x86_64')
+url="https://www.gnu.org/software/xorriso/"
+license=('GPL3')
+source=("https://www.gnu.org/software/${pkgname}/${pkgname}-${pkgver}.tar.gz"{,.sig})
+sha256sums=('ec82069e04096cd9c18be9b12b87b750ade0b5e37508978feabcde36b2278481'
+            'SKIP')
+validpgpkeys=('E9CBDFC0ABC0A854') # Thomas Schmitt <scdbackup@gmx.net>
+
+prepare() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  ./configure \
+      --prefix=/usr \
+      --enable-shared \
+      --disable-static
+  make
+}
+
+package() {
+  cd "${srcdir}/${pkgname}-${pkgver}"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
The xorriso package is useful for those following the OS development guides at http://wiki.osdev.org on Windows.  It is used to create bootable ISOs.

This is my first pull request for MSYS2.  I'm not sure if I used the 'validpgpkeys' property properly.