### PR TITLE
Rebuild all packages that have an incorrect file size in the sync databases

### DIFF
--- a/ctags/PKGBUILD
+++ b/ctags/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname="ctags"
 pkgver="5.8"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="Generate tag files for source code"
 arch=("i686" "x86_64")
 url="https://ctags.sourceforge.io/"

--- a/gengetopt/PKGBUILD
+++ b/gengetopt/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gengetopt
 pkgver=2.22.6
-pkgrel=2
+pkgrel=3
 pkgdesc="A tool to write command line option parsing code for C programs."
 arch=('i686' 'x86_64' 'arm' 'armv6h')
 url="https://www.gnu.org/software/gengetopt/gengetopt.html"

--- a/idutils/PKGBUILD
+++ b/idutils/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname="idutils"
 pkgver="4.6"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="A fast, high-capacity, identifier database tool"
 arch=("i686" "x86_64")
 url="https://www.gnu.org/software/idutils/"

--- a/perl-Compress-Bzip2/PKGBUILD
+++ b/perl-Compress-Bzip2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=Compress-Bzip2
 pkgname=perl-${_realname}
 pkgver=2.22
-pkgrel=1
+pkgrel=2
 pkgdesc="Interface to Bzip2 compression library"
 arch=(i686 x86_64)
 license=(GPL2)

--- a/task/PKGBUILD
+++ b/task/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=task
 pkgver=2.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A command-line todo list manager"
 arch=('i686' 'x86_64')
 url="https://taskwarrior.org/"

--- a/txt2tags/PKGBUILD
+++ b/txt2tags/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=txt2tags
 pkgver=2.6
-pkgrel=4
+pkgrel=5
 pkgdesc='A text formatting and conversion tool.'
 arch=('any')
 url='https://www.txt2tags.org/'


### PR DESCRIPTION
I'm relatively new to contributing, please let me know if there's a better way to go about this.

Exhaustively comparing the (presumably correct) file sizes from [the repo listings](http://repo.msys2.org/msys/) to the descriptions in both msys.db files shows ten total packages with bogus file sizes listed in msys.db. This is the root cause of #942 and friends. A simple rebuild fixed this for ucl; this PR is intended to fix the remainder.

Packages with incorrect sizes in db | [i686](http://repo.msys2.org/msys/x86_64/msys.db) | [x86_64](http://repo.msys2.org/msys/x86_64/msys.db)
-- | -- | --
ctags, gengetopt, perl-Compress-Bzip2, txt2tags | X | X
idutils, task | | X

This also agrees with @lockywolf's list in #1025.