### PR TITLE
'MSYS2-devel' group: possible typo?

### DIFF
--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=2.9.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -189,7 +189,7 @@ package_msys2-runtime() {
 
 package_msys2-runtime-devel() {
   pkgdesc="MSYS2 headers and libraries"
-  groups=('MSYS2-devel')
+  groups=('msys2-devel')
   depends=("msys2-runtime=${pkgver}")
   options=('staticlibs' '!strip')
 


### PR DESCRIPTION
The package group `MSYS2-devel` (containing only msys2-runtime-devel) was created in bcdbf402. The next day, the group `msys2-devel` was created in 1994b55. I don't know if the difference in case was on purpose, or what the consequences of changing it might be. @Alexpux, please advise?