### PR TITLE
Ruby 2.4.0, - rebuild to remove dependency on gcc's libssp library.

### DIFF
--- a/ruby/PKGBUILD
+++ b/ruby/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('ruby' 'ruby-docs')
 pkgver=2.4.0
-pkgrel=1
+pkgrel=2
 arch=('i686' 'x86_64')
 url='https://www.ruby-lang.org/en/'
 license=('BSD' 'custom')


### PR DESCRIPTION
Note that I am now working on ruby 2.5.0.