### PR TITLE
rebuild libxml2 to fix breakage with new ICU package.  This was causi…

### DIFF
--- a/libxml2/PKGBUILD
+++ b/libxml2/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('libxml2' 'libxml2-devel' 'libxml2-python')
 pkgver=2.9.7
-pkgrel=1
+pkgrel=2
 pkgdesc="XML parsing library, version 2"
 arch=(i686 x86_64)
 license=('MIT')


### PR DESCRIPTION
…ng docbook to make a catalog.