### PR TITLE
Fix issue #1107

### DIFF
--- a/filesystem/05-home-dir.post
+++ b/filesystem/05-home-dir.post
@@ -252,7 +252,8 @@ maybe_create_home ()
   # Make sure we start in home unless invoked by CHERE
   if [ ! -z "${CHERE_INVOKING}" ]; then
     unset CHERE_INVOKING
-  else
+  elif [ "${CD_HOME}" = "yes" ]; then
+    unset CD_HOME
     cd "${HOME}" || echo "WARNING: Failed attempt to cd into ${HOME}!"
   fi
 }

--- a/filesystem/05-home-dir.post
+++ b/filesystem/05-home-dir.post
@@ -227,14 +227,16 @@ maybe_create_home ()
       echo
       echo "They will never be overwritten nor automatically updated."
       echo
+      local cur_pwd="$PWD"
       cd /etc/skel || echo "WARNING: Failed attempt to cd into /etc/skel!"
       local f=
       /usr/bin/find . -type f | while read f; do
-        local fDest=${f#.}
+        local fDest="${f#.}"
         if [ ! -e "${HOME}${fDest}" -a ! -L "${HOME}${fDest}" ]; then
-          /usr/bin/install -D -p -v "${f}" "${HOME}/${fDest}"
+          /usr/bin/install -D -p -v "${f}" "${HOME}${fDest}"
         fi
       done
+      cd "${cur_pwd}"
     else
       echo "${HOME} could not be created."
       { [ -d "${TEMP}" ] && HOME="${TEMP}"; } ||

--- a/filesystem/05-home-dir.post
+++ b/filesystem/05-home-dir.post
@@ -249,13 +249,11 @@ maybe_create_home ()
   # c:\msys\usr\bin\bash -c "cd '%curdir'; export 
   # CHERE_INVOKING=1; exec /usr/bin/bash --login -i"
   # 
-  # Make sure we start in home unless invoked by CHERE
-  if [ ! -z "${CHERE_INVOKING}" ]; then
-    unset CHERE_INVOKING
-  elif [ "${CD_HOME}" = "yes" ]; then
-    unset CD_HOME
+  # Make sure we start in home if invoked through msys2_shell.cmd without -here option
+  if [ -z "${CHERE_INVOKING}" -a "${CD_HOME}" = "yes" ]; then
     cd "${HOME}" || echo "WARNING: Failed attempt to cd into ${HOME}!"
   fi
+  unset CHERE_INVOKING CD_HOME
 }
 
 maybe_create_home

--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2017.05
+pkgver=2018.02
 pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')

--- a/filesystem/msys2_shell.cmd
+++ b/filesystem/msys2_shell.cmd
@@ -68,6 +68,8 @@ if "%MSYSTEM%" == "MINGW32" (
   set "CONTITLE=MSYS2 MSYS"
 )
 
+set CD_HOME=yes
+
 if "x%MSYSCON%" == "xmintty.exe" goto startmintty
 if "x%MSYSCON%" == "xconemu" goto startconemu
 if "x%MSYSCON%" == "xdefterm" goto startsh


### PR DESCRIPTION
Instead of always changing directory to `$HOME` during shell startup, only do it when started from msys2_shell.cmd as to not break the behavior of `tmux -c` (issue #1107).