### PR TITLE
gnupg: Don't nuke pacman's keyring in post-install

### DIFF
--- a/gnupg/PKGBUILD
+++ b/gnupg/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=gnupg
 pkgver=1.4.22
-pkgrel=2
+pkgrel=3
 pkgdesc='Complete and free implementation of the OpenPGP standard'
 url='https://gnupg.org/'
 license=('GPL')

--- a/gnupg/gnupg.install
+++ b/gnupg/gnupg.install
@@ -6,10 +6,6 @@ post_install() {
   for f in ${info_files}; do
     usr/bin/install-info ${info_dir}/$f.gz ${info_dir}/dir 2> /dev/null
   done
-  
-  rm -fr etc/pacman.d/gnupg
-  pacman-key --init
-  pacman-key --populate msys2
 }
 
 post_upgrade() {


### PR DESCRIPTION
It seems this is obsolete and only makes things more difficult for Git-for-Windows and people with their own private pacman repositories. What do you think, @Alexpux?