### PR TITLE
Fix missing paste-from-clipboard command, fixes #947

### DIFF
--- a/readline/PKGBUILD
+++ b/readline/PKGBUILD
@@ -5,7 +5,7 @@ pkgname=('libreadline' 'libreadline-devel')
 _basever=7.0
 _patchlevel=003 #prepare for some patches
 pkgver=${_basever}.${_patchlevel}
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU readline library"
 arch=('i686' 'x86_64')
 url="https://tiswww.case.edu/php/chet/readline/rltop.html"
@@ -14,6 +14,7 @@ makedepends=('ncurses-devel')
 #backup=('etc/inputrc')
 options=('!emptydirs')
 source=(https://ftp.gnu.org/gnu/readline/readline-$_basever.tar.gz{,.sig}
+        readline-7.0.3-3.clipboard.patch
         readline-7.0.3-3.src.patch
         readline-6.3-msys2.patch
         readline-6.3-paste-utf8.patch)
@@ -24,6 +25,7 @@ if [ $_patchlevel -gt 00 ]; then
 fi
 sha256sums=('750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334'
             'SKIP'
+            '82289eeb21941e4b273839de68058d9f7901379615f9a481102eb874f34a7235'
             'ebb548dfd63305dff579c223857944fbf756360498ae748df4357da243f0687d'
             '4f2f97334d2e7fe362c9ef4e1fd06018d34115a8370c0323d0da67ca2b3d0761'
             '2142f1417536e2670829d3cf6f4f4f2560687a92955ccf11a121bde5dbbccbc9'
@@ -44,6 +46,7 @@ prepare() {
   patch -p2 -i ${srcdir}/readline-7.0.3-3.src.patch
   patch -p1 -i ${srcdir}/readline-6.3-msys2.patch
   patch -p1 -i ${srcdir}/readline-6.3-paste-utf8.patch
+  patch -p1 -i ${srcdir}/readline-7.0.3-3.clipboard.patch
 }
 
 build() {

--- a/readline/readline-7.0.3-3.clipboard.patch
+++ b/readline/readline-7.0.3-3.clipboard.patch
@@ -1,0 +1,36 @@
+diff -rwu orig/funmap.c readline-7.0/funmap.c
+--- orig/funmap.c	2018-03-01 18:12:03.726007400 +0900
++++ readline-7.0/funmap.c	2018-03-01 18:12:09.403227100 +0900
+@@ -116,7 +116,7 @@
+   { "non-incremental-reverse-search-history-again", rl_noninc_reverse_search_again },
+   { "old-menu-complete", rl_old_menu_complete },
+   { "overwrite-mode", rl_overwrite_mode },
+-#if defined (_WIN32)
++#if defined (_WIN32) || defined (__CYGWIN__)
+   { "paste-from-clipboard", rl_paste_from_clipboard },
+ #endif
+   { "possible-completions", rl_possible_completions },
+diff -rwu orig/kill.c readline-7.0/kill.c
+--- orig/kill.c	2018-03-01 18:12:03.813767700 +0900
++++ readline-7.0/kill.c	2018-03-01 18:12:12.417899000 +0900
+@@ -741,7 +741,7 @@
+ }
+ 
+ /* A special paste command for Windows users.. */
+-#if defined (_WIN32)
++#if defined (_WIN32) || defined (__CYGWIN__)
+ #include <windows.h>
+ 
+ static char*
+diff -rwu orig/readline.h readline-7.0/readline.h
+--- orig/readline.h	2018-03-01 18:12:03.932404000 +0900
++++ readline-7.0/readline.h	2018-03-01 18:12:08.364068200 +0900
+@@ -174,7 +174,7 @@
+ extern int rl_yank_last_arg PARAMS((int, int));
+ extern int rl_bracketed_paste_begin PARAMS((int, int));
+ /* Not available unless _WIN32 is defined. */
+-#if defined (_WIN32)
++#if defined (_WIN32) || defined (__CYGWIN__)
+ extern int rl_paste_from_clipboard PARAMS((int, int));
+ #endif
+ 


### PR DESCRIPTION
In readline 7.0 some __CYGWIN__ ifdefs wrapping the paste-from-clipboard command were changed to _WIN32, which isn't defined. I'm not sure why, but this commit adds them back. It fixes #947 which was caused when that command disappeared.