### PR TITLE
remove minor bashism from /etc/profile

### DIFF
--- a/filesystem/profile
+++ b/filesystem/profile
@@ -45,7 +45,7 @@ case "${MSYS2_PATH_TYPE:-minimal}" in
 esac
 
 unset MINGW_MOUNT_POINT
-source '/etc/msystem'
+. '/etc/msystem'
 case "${MSYSTEM}" in
 MINGW32)
   MINGW_MOUNT_POINT="${MINGW_PREFIX}"


### PR DESCRIPTION
Noticed this when using `dash` as my shell.

https://wiki.ubuntu.com/DashAsBinSh#source