### PR TITLE
Mintty

### DIFF
--- a/mintty/89819e6e26f096f8c0a139916874aae9b4d5f835.patch
+++ b/mintty/89819e6e26f096f8c0a139916874aae9b4d5f835.patch
@@ -1,0 +1,83 @@
+From 89819e6e26f096f8c0a139916874aae9b4d5f835 Mon Sep 17 00:00:00 2001
+From: mintty <mintty@users.noreply.github.com>
+Date: Wed, 18 Apr 2018 08:34:04 +0200
+Subject: [PATCH] gcc 7.3.0 (#765)
+
+---
+ src/child.c     | 12 ++++++------
+ src/term.c      |  4 ++--
+ src/termmouse.c |  4 ++--
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/child.c b/src/child.c
+index bd69ceb8..a2d7ad87 100644
+--- a/src/child.c
++++ b/src/child.c
+@@ -504,17 +504,17 @@ child_is_parent(void)
+ {
+   if (!pid)
+     return false;
+-  DIR *d = opendir("/proc");
++  DIR * d = opendir("/proc");
+   if (!d)
+     return false;
+   bool res = false;
+-  struct dirent *e;
+-  char fn[18] = "/proc/";
++  struct dirent * e;
+   while ((e = readdir(d))) {
+-    char *pn = e->d_name;
++    char * pn = e->d_name;
+     if (isdigit((uchar)*pn) && strlen(pn) <= 6) {
+-      snprintf(fn + 6, 12, "%s/ppid", pn);
+-      FILE *f = fopen(fn, "r");
++      char * fn = asform("/proc/%s/ppid", pn);
++      FILE * f = fopen(fn, "r");
++      free(fn);
+       if (!f)
+         continue;
+       pid_t ppid = 0;
+diff --git a/src/term.c b/src/term.c
+index c75de9ab..4ee60cb9 100644
+--- a/src/term.c
++++ b/src/term.c
+@@ -1353,7 +1353,7 @@ fallback:;
+       return false;
+   }
+   char * en = strdup(pre);
+-  char ec[6];
++  char ec[7];
+   if (e.seq) {
+     for (uint i = 0; i < lengthof(emoji_seqs->chs) && ed(emoji_seqs[e.idx].chs[i]); i++) {
+       xchar xc = ed(emoji_seqs[e.idx].chs[i]);
+@@ -1366,7 +1366,7 @@ fallback:;
+     }
+   }
+   else {
+-    sprintf(ec, "%04x", emoji_bases[e.idx].ch);
++    snprintf(ec, 7, "%04x", emoji_bases[e.idx].ch);
+     strappend(en, ec);
+   }
+   strappend(en, suf);
+diff --git a/src/termmouse.c b/src/termmouse.c
+index dd6a0e5e..af0c6592 100644
+--- a/src/termmouse.c
++++ b/src/termmouse.c
+@@ -132,7 +132,7 @@ sel_spread_half(pos p, bool forward)
+           p.y--;
+         }
+       }
+-    default:
++    otherwise:
+      /* Shouldn't happen. */
+       break;
+   }
+@@ -537,7 +537,7 @@ term_mouse_release(mouse_button b, mod_keys mods, pos p)
+       moved_previously = true;
+       last_dest = dest;
+     }
+-    default:
++    otherwise:
+       if (is_app_mouse(&mods)) {
+         if (term.mouse_mode >= MM_VT200)
+           send_mouse_event(MA_RELEASE, b, mods, box_pos(p));

--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=mintty
-pkgver=2.8.4
+pkgver=2.8.5
 pkgrel=1
 epoch=1
 pkgdesc="Terminal emulator with native Windows look and feel"
@@ -13,7 +13,7 @@ url="https://mintty.github.io"
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
         0002-add-msys2-launcher.patch
         0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch)
-sha256sums=('bc1ffa533a375c406685206d06660b1e8d3f5ee9ee865ef426af2807241fe4aa'
+sha256sums=('e635a1bfa05bc440691cf5e3892024ee1c58beb329ca8117eab165a8a1a5314b'
             '2206240168fa481e54346406e96820a1e0a678a9cc21076bd8fac4c97c527dd4'
             'd2398c8586c8eaa04dc2f49d663855f420a17feec918f6ac63a8b975037cd86c')
 

--- a/mintty/PKGBUILD
+++ b/mintty/PKGBUILD
@@ -11,9 +11,11 @@ groups=('base')
 depends=('sh')
 url="https://mintty.github.io"
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mintty/mintty/archive/${pkgver}.tar.gz
+        89819e6e26f096f8c0a139916874aae9b4d5f835.patch
         0002-add-msys2-launcher.patch
         0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch)
 sha256sums=('e635a1bfa05bc440691cf5e3892024ee1c58beb329ca8117eab165a8a1a5314b'
+            'b71df625e690b1b6441d76b4f62ed5a632ec67f366695b2c79f5d90be95c6503'
             '2206240168fa481e54346406e96820a1e0a678a9cc21076bd8fac4c97c527dd4'
             'd2398c8586c8eaa04dc2f49d663855f420a17feec918f6ac63a8b975037cd86c')
 
@@ -29,6 +31,7 @@ del_file_exists() {
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   del_file_exists src/launcher.c src/launcher.h
+  patch -p1 -i ${srcdir}/89819e6e26f096f8c0a139916874aae9b4d5f835.patch
   patch -p1 -i ${srcdir}/0002-add-msys2-launcher.patch
   patch -p1 -i ${srcdir}/0003-fix-current-dir-inheritance-for-alt-f2-on-msys2.patch
 }
@@ -47,6 +50,7 @@ package() {
   mkdir -p ${pkgdir}/usr/share/${pkgname}/themes
 
   install -m755 bin/mintty.exe ${pkgdir}/usr/bin/mintty.exe
+  install -m755 tools/* ${pkgdir}/usr/bin/
   install -m644 docs/mintty.1 ${pkgdir}/usr/share/man/man1/mintty.1
 
   install -m644 LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/


### PR DESCRIPTION
Include a patch for an issue I reported at:

https://github.com/mintty/mintty/issues/765

This is to ensure that this compiles with GCC 7.2 >.   GCC 7.2 had tightened up on some warnings with formatting and fall through.