### PR TITLE
msys2-runtime: Cherry-pick gcc 7 suport from cygwin

### DIFF
--- a/msys2-runtime/0024-Cygwin-fix-build-with-GCC-7.patch
+++ b/msys2-runtime/0024-Cygwin-fix-build-with-GCC-7.patch
@@ -1,0 +1,48 @@
+From 67609efeb0bcb198463a952a6a214813794a9c2b Mon Sep 17 00:00:00 2001
+From: Yaakov Selkowitz <yselkowi@redhat.com>
+Date: Mon, 16 Apr 2018 22:46:11 -0500
+Subject: [PATCH 24/24] Cygwin: fix build with GCC 7
+
+GCC 7 is able to see straight through this trick, so use a more formal
+method to avoid the warning.
+
+Signed-off-by: Yaakov Selkowitz <yselkowi@redhat.com>
+---
+ winsup/cygwin/random.cc | 14 +++++---------
+ 1 file changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/winsup/cygwin/random.cc b/winsup/cygwin/random.cc
+index 802c33b8a..163fc040c 100644
+--- a/winsup/cygwin/random.cc
++++ b/winsup/cygwin/random.cc
+@@ -279,14 +279,6 @@ srandom(unsigned x)
+ 		(void)random();
+ }
+ 
+-/* Avoid a compiler warning when we really want to get at the junk in
+-   an uninitialized variable. */
+-static unsigned long
+-dummy (unsigned volatile long *x)
+-{
+-  return *x;
+-}
+-
+ /*
+  * srandomdev:
+  *
+@@ -313,7 +305,11 @@ srandomdev()
+ 		unsigned long junk;
+ 
+ 		gettimeofday(&tv, NULL);
+-		srandom((getpid() << 16) ^ tv.tv_sec ^ tv.tv_usec ^ dummy(&junk));
++		/* Avoid a compiler warning when we really want to get at the
++		   junk in an uninitialized variable. */
++#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
++		srandom((getpid() << 16) ^ tv.tv_sec ^ tv.tv_usec ^ junk);
++#pragma GCC diagnostic pop
+ 		return;
+ 	}
+ 
+-- 
+2.16.2.windows.1
+

--- a/msys2-runtime/PKGBUILD
+++ b/msys2-runtime/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=msys2-runtime
 pkgname=('msys2-runtime' 'msys2-runtime-devel')
 pkgver=2.10.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cygwin POSIX emulation engine"
 arch=('i686' 'x86_64')
 url="https://www.cygwin.com/"
@@ -46,6 +46,7 @@ source=('msys2-runtime'::git://sourceware.org/git/newlib-cygwin.git#tag=cygwin-$
         0021-Add-debugging-for-strace-make_command_line.patch
         0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch
         0023-path.cc-Ignore-zero-length-exclusions.patch
+        0024-Cygwin-fix-build-with-GCC-7.patch
 )
 sha256sums=('SKIP'
             '8aafdf4f62a52195a591ebe24ab671c35aa1d7c60381c8ff3526c4c1dd1fdf0e'
@@ -70,7 +71,8 @@ sha256sums=('SKIP'
             '09972073fe07623ad8bbfdec9c7c33fd75e12cd9d237aef3c04468a9aefa4afd'
             'ac80823274db00b877f1e925426da1a709f00b211f77e30fe4448f5c6c31194a'
             'a0fe210a8ae05f0a17a06ff79736d0908a6c3dc0fc6db444e5c4d050b84b779d'
-            '7cba394680f874b23fa77ea295d17f4b2a2a5f64bd376cd6afd6cf34b05f659b')
+            '7cba394680f874b23fa77ea295d17f4b2a2a5f64bd376cd6afd6cf34b05f659b'
+            '6bf4d9abd0ec1cf3de0868df81792d3cdf4d857eb8002fd9dd8505f9541a8c29')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -125,7 +127,8 @@ prepare() {
   0020-Add-debugging-for-build_argv.patch \
   0021-Add-debugging-for-strace-make_command_line.patch \
   0022-environ.cc-New-facility-environment-variable-MSYS2_E.patch \
-  0023-path.cc-Ignore-zero-length-exclusions.patch
+  0023-path.cc-Ignore-zero-length-exclusions.patch \
+  0024-Cygwin-fix-build-with-GCC-7.patch
 
 }
 


### PR DESCRIPTION
This cherry-picks commit 67609efeb0bcb198463a952a6a214813794a9c2b from cygwin upstream, see https://www.mail-archive.com/cygwin-patches@cygwin.com/msg06820.html