### PR TITLE
Make  CHERE_INVOKING visible for bash users.

### DIFF
--- a/filesystem/05-home-dir.post
+++ b/filesystem/05-home-dir.post
@@ -253,6 +253,7 @@ maybe_create_home ()
   # 
   # Make sure we start in home if invoked without -here option and not in a nested shell
   if [ ! -z "${CHERE_INVOKING}" ]; then
+    CHERE_INVOKING_VISIBLE_FOR_USER=$CHERE_INVOKING
     unset CHERE_INVOKING
   elif [ ${SHLVL:-0} -le 1 ]; then
     cd "${HOME}" || echo "WARNING: Failed attempt to cd into ${HOME}!"


### PR DESCRIPTION
Enables users to take action (e.g. in `~/.bash_profile`) if msys was invoked with `CHERE_INVOKING` set.
Example usage:
`~/.bash_profile`:
```bash
  # Change to pwd at last logout unless $CHERE_INVOKING was set
  if [ ! -z "${CHERE_INVOKING_VISIBLE_FOR_USER}" ]; then
    unset CHERE_INVOKING_VISIBLE_FOR_USER
  else
    [ -s ~/.lastdirectory ] && cd `cat ~/.lastdirectory`
  fi
```
`~/.bash_logout`:
```bash
  pwd > ~/.lastdirectory
```