### PR TITLE
Make CHERE_INVOKING visible for users.

### DIFF
--- a/filesystem/05-home-dir.post
+++ b/filesystem/05-home-dir.post
@@ -253,6 +253,7 @@ maybe_create_home ()
   # 
   # Make sure we start in home if invoked without -here option and not in a nested shell
   if [ ! -z "${CHERE_INVOKING}" ]; then
+    CHERE_INVOKING_VISIBLE_FOR_USER=CHERE_INVOKING
     unset CHERE_INVOKING
   elif [ ${SHLVL:-0} -le 1 ]; then
     cd "${HOME}" || echo "WARNING: Failed attempt to cd into ${HOME}!"


### PR DESCRIPTION
Enables users to take action (e.g. in `~/.bash_profile`) if msys was invoked with `CHERE_INVOKING` set.

`CHERE_INVOKING` is unset in the [original code](https://github.com/Alexpux/MSYS2-packages/blob/04890265df2539ff0399bb05d97ffc67d94027ac/filesystem/05-home-dir.post#L256). To make it visible to users it is [copied into a new variable](https://github.com/henrik-jensen/MSYS2-packages/blob/714549756f6eff42b5b950ce40fcfc1a5515a225/filesystem/05-home-dir.post#L256), `CHERE_INVOKING_VISIBLE_FOR_USER`, before unsetting in the PR. If the user choose to use this new variable it is their responsibility to unset this variable. ( Please propose a better naming if you have one )

Example usage ( Start in same directory as at last logout ):
Add to `~/.bash_profile`:
```bash
  # Change to pwd at last logout unless $CHERE_INVOKING was set
  if [ ! -z "${CHERE_INVOKING_VISIBLE_FOR_USER}" ]; then
    unset CHERE_INVOKING_VISIBLE_FOR_USER
  else
    [ -s ~/.lastdirectory ] && cd `cat ~/.lastdirectory`
  fi
```
Add to `~/.bash_logout`:
```bash
  pwd > ~/.lastdirectory
```
