### PR TITLE
bash-completion: update to 2.8

### DIFF
--- a/bash-completion/PKGBUILD
+++ b/bash-completion/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=bash-completion
-pkgver=2.5
+pkgver=2.8
 pkgrel=1
 pkgdesc="Programmable completion for the bash shell"
 arch=('any')
@@ -12,7 +12,7 @@ depends=('bash')
 options=('!emptydirs' '!makeflags')
 source=(https://github.com/scop/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.xz
         quote_readline_by_ref_fixes.patch)
-sha256sums=('b0b9540c65532825eca030f1241731383f89b2b65e80f3492c5dd2f0438c95cf'
+sha256sums=('c01f5570f5698a0dda8dc9cfb2a83744daa1ec54758373a6e349bd903375f54d'
             'f1b95da22e56909681ac05e08bfcc497cecfdad1060902ca415d54d2d0b265a3')
 prepare() {
   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
This updates bash-completion to 2.8.