### PR TITLE
diffutils: Update to 3.6

### DIFF
--- a/diffutils/PKGBUILD
+++ b/diffutils/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=diffutils
-pkgver=3.5
+pkgver=3.6
 pkgrel=1
 pkgdesc="Utility programs used for creating patch files"
 arch=('i686' 'x86_64')
@@ -12,7 +12,7 @@ depends=('msys2-runtime' 'sh')
 install=diffutils.install
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
         diffutils-3.3-msys2.patch)
-sha256sums=('dad398ccd5b9faca6b0ab219a036453f62a602a56203ac659b43e889bec35533'
+sha256sums=('d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6'
             'SKIP'
             'd58d5ee8c7b889a5027a43ce6d7f4ff5fc3d8927e389290c347ee9be094f6242')
 
@@ -25,6 +25,10 @@ prepare() {
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
+
+  # make sure tests are running OK
+  sed -i "s/mkdir -m 0700/mkdir /" tests/init.sh
+
   ./configure --build=${CHOST} \
     --prefix=/usr \
     --without-libiconv-prefix \


### PR DESCRIPTION
make check resulted:
```
===================================================================
Testsuite summary for GNU diffutils 3.6
===================================================================
# TOTAL: 20
# PASS:  18
# SKIP:  1
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

```

The failing one is the `no-dereference`, but I believe that's expected, as it is using symlinks.