### PR TITLE
grep: Update to 3.1

### DIFF
--- a/grep/PKGBUILD
+++ b/grep/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=grep
-pkgver=3.0
+pkgver=3.1
 pkgrel=1
 pkgdesc="A string search utility"
 arch=('i686' 'x86_64')
@@ -14,7 +14,7 @@ install=${pkgname}.install
 source=(https://ftp.gnu.org/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig}
         grep-2.23-msys2.patch
         grep-3.0-2.src.patch)
-sha256sums=('e2c81db5056e3e8c5995f0bb5d0d0e1cad1f6f45c3b2fc77b6e81435aed48ab5'
+sha256sums=('db625c7ab3bb3ee757b3926a5cfa8d9e1c3991ad24707a83dde8a5ef2bf7a07e'
             'SKIP'
             '9b9b87f5aa12c49e4e4403d27b85fef3f1de252dfe4eed1a7a4f982ef515a95a'
             '0b2e7e54eb4d5b13257c1b4b43bcb234be02ded8fd04dfbbb73a92346e8b2db2')
@@ -27,12 +27,20 @@ prepare() {
   # Once this will be commit upstream we need revert it
   # patch -p2 -R -i ${srcdir}/grep-3.0-2.src.patch
 
+  #make test cases work
+  sed -i "s|case \$perms in drwx--\[-S\]---\*|case \$perms in drwx\*|" tests/init.sh
+
   autoreconf -fi
 }
 
 build() {
   cd ${srcdir}/${pkgname}-${pkgver}
-  ./configure --build=${CHOST} \
+
+  echo ${CHOST}
+  ./configure \
+      --build=${CHOST} \
+      --host=${CHOST} \
+      --target=${CHOST} \
       --prefix=/usr \
       --without-libiconv-prefix \
       --without-libintl-prefix


### PR DESCRIPTION
```
============================================================================
Testsuite summary for GNU grep 3.1
============================================================================
# TOTAL: 109
# PASS:  98
# SKIP:  7
# XFAIL: 2
# FAIL:  1
# XPASS: 0
# ERROR: 1
============================================================================

```