### PR TITLE
openbsd-netcat: Update to 1.190

### DIFF
--- a/openbsd-netcat/PKGBUILD
+++ b/openbsd-netcat/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: LoveSy <shana@zju.edu.cn>
 
 pkgname="openbsd-netcat"
-pkgver=1.130
-pkgrel=3
+pkgver=1.190
+pkgrel=2
 pkgdesc="TCP/IP swiss army knife. OpenBSD variant."
 arch=('i686' 'x86_64')
 url="https://packages.debian.org/sid/netcat-openbsd"
@@ -12,9 +12,9 @@ conflicts=('gnu-netcat')
 source=("http://ftp.debian.org/debian/pool/main/n/netcat-openbsd/netcat-openbsd_${pkgver}.orig.tar.gz"
 	"http://ftp.debian.org/debian/pool/main/n/netcat-openbsd/netcat-openbsd_${pkgver}-${pkgrel}.debian.tar.xz"
     'openbsd-netcat.patch')
-sha256sums=('fd7205065d0b47898851f31f33e614de5d47a5b9dc81fd50d2ff51b63d091e5b'
-            '2a41980c0c81159243ef7b97480241bb6c23f9c9bab81fea51689b2a77022439'
-            'SKIP')
+sha256sums=('68ccc448392c05ec51baed0167a72b8c650454f990b895d6e6877d416a38e536'
+            '88088af3f520c7825e59bc133d65e70fc4a30139d451c6faabbd9f240bc78374'
+            'a55a35b0dc3a600324295235a7eea5dc5abada6e5506ba318087abd6c0c7766c')
 
 prepare() {
   cd "$srcdir"/netcat-openbsd-${pkgver%_*}

--- a/openbsd-netcat/openbsd-netcat.patch
+++ b/openbsd-netcat/openbsd-netcat.patch
@@ -1663,15 +1663,15 @@ diff -uprN netcat-openbsd-1.130.bk/netcat.c netcat-openbsd-1.130/netcat.c
  
  # ifndef IPTOS_DSCP_AF11
 @@ -96,8 +98,7 @@
- #include <stdlib.h>
- #include <string.h>
+ # include <tls.h>
+ #endif
  #include <unistd.h>
 -#include <bsd/stdlib.h>
 -#include <bsd/string.h>
 +#include <sys/cdefs.h>
- #include "atomicio.h"
  
- #ifndef SUN_LEN
+  #include "atomicio.h"
+ 
 @@ -180,7 +181,11 @@ static int connect_with_timeout(int fd,
          socklen_t salen, int ctimeout);
  


### PR DESCRIPTION
`pkgrel `is deliberately 2 due to the debian patchset.