### PR TITLE
Automatically check for (unintended) dll dependencies

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -28,6 +28,7 @@ for package in "${packages[@]}"; do
     execute 'Building binary' makepkg --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource
     execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.xz
+    execute 'Checking dll depencencies' list_dll_deps ./pkg
     deploy_enabled && mv "${package}"/*.pkg.tar.xz artifacts
     deploy_enabled && mv "${package}"/*.src.tar.gz artifacts
     unset package

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -200,6 +200,13 @@ check_recipe_quality() {
     saneman --format='\t%l:%c %p:%c %m' --verbose --no-terminal "${packages[@]}"
 }
 
+# List DDL dependencies
+list_dll_deps(){
+    local target="${1}"
+    echo "$(tput setaf 2)MSYS2 DLL dependencies:$(tput sgr0)"
+    ldd $(find $target -regex ".*\.\(exe\|dll\)") | grep --color "msys-.*\|"
+}
+
 # Status functions
 failure() { local status="${1}"; local items=("${@:2}"); _status failure "${status}." "${items[@]}"; exit 1; }
 success() { local status="${1}"; local items=("${@:2}"); _status success "${status}." "${items[@]}"; exit 0; }

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -94,3 +94,4 @@ package_libcurl-devel() {
   cp -rf ${srcdir}/dest/usr/include ${pkgdir}/usr/
   cp -rf ${srcdir}/dest/usr/lib ${pkgdir}/usr/
 }
+


### PR DESCRIPTION
A little script that shows dll dependencies in the CI script. This way we can manually inspect if there are any unlisted msys2 dependencies.

I modified the `curl` `PKGBUILD` only for testing this script :) We don't have to merge that part.