### PR TITLE
Add new package iperf3 version 3.3

### DIFF
--- a/iperf3/PKGBUILD
+++ b/iperf3/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+
+pkgname=iperf3
+pkgver=3.3
+pkgrel=1
+pkgdesc='TCP, UDP, and SCTP network bandwidth measurement tool'
+arch=('i686' 'x86_64')
+url="https://github.com/esnet/iperf"
+license=('BSD')
+depends=('msys2-runtime' 'gcc-libs' 'openssl')
+source=("http://downloads.es.net/pub/iperf/iperf-${pkgver}.tar.gz")
+sha256sums=('6f596271251056bffc11bbb8f17d4244ad9a7d4a317c2459fdbb853ae51284d8')
+
+build() {
+  cd ${srcdir}/iperf-${pkgver}
+  ./configure --build=${CHOST} \
+              --prefix=/usr
+
+  make
+}
+
+check() {
+  cd ${srcdir}/iperf-${pkgver}
+  make check
+}
+
+package() {
+  cd ${srcdir}/iperf-${pkgver}
+  make DESTDIR=${pkgdir} install
+  install -Dm 644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -Dm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+  install -Dm 644 examples/*{.am,.in,.c} -t "${pkgdir}/usr/share/doc/${pkgname}/examples"
+}


### PR DESCRIPTION
Add new package iperf3 version 3.3:
TCP, UDP, and SCTP network bandwidth measurement tool

iperf3 is incompatible with iperf and offers additional benchmark tests like SCTP testing, it also lacks iperf multithread functionality, so it would be beneficial to have them both.