### PR TITLE
New package: brotli 1.0.5

### DIFF
--- a/brotli/PKGBUILD
+++ b/brotli/PKGBUILD
@@ -1,0 +1,71 @@
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+
+pkgbase=brotli
+pkgname=('brotli' 'python-brotli' 'python2-brotli' 'brotli-testdata')
+#pkgname='brotli'
+pkgver=1.0.5
+pkgrel=1
+pkgdesc='Brotli compression library'
+arch=('i686' 'x86_64')
+license=('MIT')
+url='https://github.com/google/brotli'
+depends=('msys2-runtime' 'gcc-libs')
+makedepends=('cmake' 'python' 'python2')
+source=("$pkgbase-$pkgver.tar.gz::https://github.com/google/$pkgbase/archive/v$pkgver.tar.gz")
+sha256sums=('3d5bedd48edb909fe3b87cb99f7d139b987ef6f1616b7e22d74e928270a2fd20')
+
+prepare() {
+  cp -a brotli-$pkgver{,-py2}
+  mkdir -p build
+}
+
+build() {
+  cd "$srcdir"/brotli-$pkgver
+  python setup.py build
+
+  cd "$srcdir"/brotli-$pkgver-py2
+  python2 ./setup.py build
+
+  cd "$srcdir"/build
+  cmake ../brotli-$pkgver -DCMAKE_INSTALL_PREFIX="/usr" -DCMAKE_INSTALL_LIBDIR="/usr/lib"
+
+  make
+}
+
+check() {
+  cd brotli-$pkgver
+  make test
+}
+
+package_brotli() {
+  cd build
+  make DESTDIR=${pkgdir} install
+  install -D -m644 "${srcdir}"/brotli-$pkgver/LICENSE "${pkgdir}/usr/share/licenses/$pkgname/LICENSE"
+}
+
+package_python-brotli() {
+  depends=('python')
+
+  cd brotli-$pkgver
+
+  python setup.py install --skip-build -O1 --root="$pkgdir"
+  install -D -m644 "$srcdir"/brotli-$pkgver/LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}
+
+package_python2-brotli() {
+  depends=('python2')
+
+  cd brotli-$pkgver-py2
+
+  python2 setup.py install --skip-build -O1 --root="$pkgdir"
+  install -D -m644 "$srcdir"/brotli-$pkgver/LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}
+
+package_brotli-testdata() {
+  depends=()
+
+  cd brotli-$pkgver
+  install -dm755 "$pkgdir"/usr/share/brotli
+  cp -a tests/testdata "$pkgdir"/usr/share/brotli/
+  install -D -m644 "$srcdir"/brotli-$pkgver/LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}


### PR DESCRIPTION
Add brotli 1.0.5:
Brotli compression library

Brotli is a data format specification[1] for data streams compressed with a specific combination of the general-purpose LZ77 lossless compression algorithm, Huffman coding and 2nd order context modelling. Brotli was initially developed to decrease the size of transmissions of WOFF2 web fonts, and in that context was a continuation of the development of zopfli, which is a zlib-compatible implementation of the standard gzip and deflate specifications. Brotli allows a denser packing than gzip and deflate because of several algorithmic and format level improvements: the use of context models for literals and copy distances, describing copy distances through past distances, use of move-to-front queue in entropy code selection, joint-entropy coding of literal and copy lengths, the use of graph algorithms in block splitting, and a larger backward reference window are example improvements. The Brotli specification was generalized in September 2015 for HTTP stream compression (content-encoding type 'br'), and can now be used to encode any data sent by a web server to a web browser if both client and server support the format. This generalized iteration also improved the compression ratio by using a pre-defined dictionary of frequently-used words and phrases.
https://en.wikipedia.org/wiki/Brotli

