### PR TITLE
Remove getopt from base group

### DIFF
--- a/getopt/PKGBUILD
+++ b/getopt/PKGBUILD
@@ -2,12 +2,11 @@
 
 pkgname=getopt
 pkgver=1.1.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Utility to help shell scripts parse command-line parameters"
 arch=('i686' 'x86_64')
 url="http://software.frodo.looijaard.name/getopt/"
 license=('GPL2')
-groups=('base')
 depends=('msys2-runtime' 'sh')
 options=('!emptydirs')
 source=(http://frodo.looijaard.name/system/files/software/getopt/${pkgname}-${pkgver}.tar.gz)


### PR DESCRIPTION
getopt and util-linux are in conflict and they are both in base group so getopt should be excluded