### PR TITLE
cloog: Update to 0.19.0

### DIFF
--- a/cloog/PKGBUILD
+++ b/cloog/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Allan McRae <allan@archlinux.org>
 
 pkgname=('cloog' 'cloog-devel')
-pkgver=0.18.4
+pkgver=0.19.0
 pkgrel=1
 groups=('libraries')
 pkgdesc="Library that generates loops for scanning polyhedra"
@@ -11,18 +11,20 @@ url="https://www.bastoul.net/cloog/"
 license=('GPL')
 depends=('isl')
 makedepends=('isl-devel')
-source=(https://www.bastoul.net/cloog/pages/download/${pkgname}-${pkgver}.tar.gz
+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/periscop/cloog/releases/download/${pkgname}-${pkgver}/${pkgname}-${pkgver}.tar.gz
         cloog-0.18.4-msys2.patch
-        cloog-0.18.4-no-undefined.patch)
-sha256sums=('325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e'
+        cloog-0.18.4-no-undefined.patch
+        cloog-019.1-dont-build-doc.patch)
+sha256sums=('2ea26f29595b57d7ba731a628025f95e5c92838c44736adff89ba1a2c2484d8e'
             'fc4c552e4ce633f4f99bb7f4b59078ee1edd89728f66d044b314a2ffff88c552'
-            '8233e5cf165bbe3aab553b560b48128d059e879398274b9c847888119c469a31')
+            '8233e5cf165bbe3aab553b560b48128d059e879398274b9c847888119c469a31'
+            'f960d873bace207a3b7e575560c503ed87833c5d045be45a134ba2e7f6fc1ac3')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   patch -p1 -i ${srcdir}/cloog-0.18.4-msys2.patch
   patch -p1 -i ${srcdir}/cloog-0.18.4-no-undefined.patch
-
+  patch -p1 -i ${srcdir}/cloog-019.1-dont-build-doc.patch
   WANT_AUTOMAKE=latest autoreconf -fiv
 }
 

--- a/cloog/cloog-019.1-dont-build-doc.patch
+++ b/cloog/cloog-019.1-dont-build-doc.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am.orig	2018-07-15 16:11:53.971108000 +0200
++++ a/Makefile.am	2018-07-15 17:20:52.885833600 +0200
+@@ -181,19 +181,6 @@
+ 	@echo "              *-----------------------------------------------*/"
+ 	doxygen ./autoconf/Doxyfile
+ 
+-#/*****************************************************************************
+-# *                                   Doc                                     *
+-# *****************************************************************************/
+-
+-if HAVE_TEXI2DVI
+-pdf_DATA = doc/cloog.pdf
+-dist_pdf_DATA = doc/cloog.pdf
+-doc/cloog.pdf: doc/cloog.texi doc/gitversion.texi
+-	$(TEXI2DVI) -I $(top_builddir)/doc --pdf $< -o $@
+-endif
+-
+-doc/gitversion.texi: @GIT_INDEX@
+-	echo '@set VERSION '`$(top_builddir)/genversion.sh`'' > $@
+ 
+ #/*****************************************************************************
+ # *                                   Tests                                    *


### PR DESCRIPTION
```
============================================================================
Testsuite summary for cloog 0.19.0
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

```