### PR TITLE
Perl: Multiple updates

### DIFF
--- a/perl-Mozilla-CA/PKGBUILD
+++ b/perl-Mozilla-CA/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Mozilla-CA
 pkgname=perl-${_realname}
-pkgver=20160104
+pkgver=20180117
 pkgrel=1
 pkgdesc="Mozilla's CA cert bundle in PEM format"
 arch=('any')
@@ -12,7 +12,7 @@ depends=('perl>=5.006')
 url="https://metacpan.org/release/Mozilla-CA"
 groups=('perl-modules')
 source=("https://www.cpan.org/authors/id/A/AB/ABH/${_realname}-${pkgver}.tar.gz")
-sha256sums=('27a7069a243162b65ada4194ff9d21b6ebc304af723eb5d3972fb74c11b03f2a')
+sha256sums=('f2cc9fbe119f756313f321e0d9f1fac0859f8f154ac9d75b1a264c1afdf4e406')
 
 build() {
   cd ${_realname}-${pkgver}

--- a/perl-Test-Fatal/PKGBUILD
+++ b/perl-Test-Fatal/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Peter Budai <peterbudai@hotmail.com>
+
+_realname=Test-Fatal
+pkgname=perl-${_realname}
+pkgver=0.014
+pkgrel=1
+pkgdesc="Incredibly simple helpers for testing code with exceptions"
+arch=('any')
+url="https://metacpan.org/release/Test-Fatal"
+groups=('perl-modules')
+depends=('perl' 'perl-Try-Tiny')
+license=('GPL' 'PerlArtistic')
+source=("http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Test-Fatal-${pkgver}.tar.gz")
+sha256sums=('bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+  make
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make install DESTDIR="${pkgdir}"
+}

--- a/perl-Test-Needs/PKGBUILD
+++ b/perl-Test-Needs/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Peter Budai <peterbudai@hotmail.com>
+
+_realname=Test-Needs
+pkgname=perl-${_realname}
+pkgver=0.002005
+pkgrel=1
+pkgdesc="Skip tests when modules not available"
+arch=('any')
+url="https://metacpan.org/release/Test-Needs"
+groups=('perl-modules')
+depends=('perl')
+license=('PerlArtistic')
+source=("https://cpan.metacpan.org/authors/id/H/HA/HAARG/Test-Needs-${pkgver}.tar.gz")
+sha256sums=('5a4f33983586edacdbe00a3b429a9834190140190dab28d0f873c394eb7df399')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+  make
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make install DESTDIR="${pkgdir}"
+}

--- a/perl-Test-Pod/PKGBUILD
+++ b/perl-Test-Pod/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=Test-Pod
 pkgname=perl-${_realname}
-pkgver=1.51
+pkgver=1.52
 pkgrel=1
 pkgdesc="Check for POD errors in files"
 arch=('any')
@@ -12,7 +12,7 @@ depends=('perl' 'perl-Module-Build')
 options=('!emptydirs')
 groups=('perl-modules')
 source=(https://www.cpan.org/authors/id/E/ET/ETHER/${_realname}-${pkgver}.tar.gz)
-sha256sums=('c1a1d3cedf4a579e3aad89c36f9878a8542b6656dbe71f1581420f49582d7efb')
+sha256sums=('60a8dbcc60168bf1daa5cc2350236df9343e9878f4ab9830970a5dde6fe8e5fc')
 
 build() {
   cd ${_realname}-${pkgver}

--- a/perl-Test-Requiresinternet/PKGBUILD
+++ b/perl-Test-Requiresinternet/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Peter Budai <peterbudai@hotmail.com>
+
+_realname=Test-Requiresinternet
+pkgname=perl-${_realname}
+pkgver=0.05
+pkgrel=1
+pkgdesc="Easily test network connectivity"
+arch=('any')
+url="http://search.mcpan.org/dist/Test-RequiresInternet"
+groups=('perl-modules')
+depends=('perl')
+license=('GPL' 'PerlArtistic')
+source=("http://search.mcpan.org/CPAN/authors/id/M/MA/MALLEN/Test-RequiresInternet-${pkgver}.tar.gz")
+sha256sums=('bba7b32a1cc0d58ce2ec20b200a7347c69631641e8cae8ff4567ad24ef1e833e')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+  make
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make install DESTDIR="${pkgdir}"
+}

--- a/perl-URI/PKGBUILD
+++ b/perl-URI/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=URI
 pkgname=perl-${_realname}
-pkgver=1.73
+pkgver=1.74
 pkgrel=1
 pkgdesc="Uniform Resource Identifiers (absolute and relative)"
 arch=('any')
@@ -10,10 +10,11 @@ url="http://search.cpan.org/dist/${_realname}/"
 groups=('perl-modules')
 license=('PerlArtistic')
 depends=('perl>=5.10.0')
+checkdepends=('perl-Test-Needs')
 provides=('perl-URI-Escape=3.30')
 options=('!emptydirs')
 source=("https://cpan.metacpan.org/authors/id/E/ET/ETHER/${_realname}-${pkgver}.tar.gz")
-sha256sums=('cca7ab4a6f63f3ccaacae0f2e1337e8edf84137e73f18548ec7d659f23efe413')
+sha256sums=('a9c254f45f89cb1dd946b689dfe433095404532a4543bdaab0b71ce0fdcdd53d')
 
 build() {
   cd "${srcdir}/${_realname}-$pkgver"

--- a/perl-XML-SAX/PKGBUILD
+++ b/perl-XML-SAX/PKGBUILD
@@ -2,8 +2,8 @@
 
 _realname=XML-SAX
 pkgname=perl-${_realname}
-pkgver=0.99
-pkgrel=2
+pkgver=1.00
+pkgrel=1
 pkgdesc="Simple API for XML"
 arch=('any')
 url="http://search.cpan.org/dist/XML-SAX"
@@ -14,8 +14,8 @@ options=('!emptydirs')
 install=perl-xml-sax.install
 source=("https://www.cpan.org/authors/id/G/GR/GRANTM/${_realname}-${pkgver}.tar.gz"
         'perl-xml-sax.patch')
-sha256sums=('32b04b8e36b6cc4cfc486de2d859d87af5386dd930f2383c49347050d6f5ad84'
-            'cf5452ccd81b7eb9cd50315a25747099628a6c0442ea3a6c3849edc3e7e4af18')
+sha256sums=('45ea6564ef8692155d57b2de0862b6442d3c7e29f4a9bc9ede5d7ecdc74c2ae3'
+            '79cd182088243cae4a78448df35e0dc17448f5acbfb2dcce222f6d1100ab6280')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/perl-XML-SAX/perl-xml-sax.patch
+++ b/perl-XML-SAX/perl-xml-sax.patch
@@ -1,10 +1,9 @@
 --- a/Makefile.PL	2011-09-04 23:37:48.000000000 +0200
 +++ b/Makefile.PL	2011-10-07 18:12:50.000000000 +0200
-@@ -12,43 +12,3 @@
-         'XML::NamespaceSupport' => 0.03,
+@@ -13,42 +13,4 @@
      },    
  );
--
+ 
 -sub MY::install {
 -    package MY;
 -    my $script = shift->SUPER::install(@_);
@@ -34,7 +33,7 @@
 -        $script =~ s/install :: (.*)$/install :: $1 install_sax_pureperl/m;
 -        $script .= <<"INSTALL";
 -
--install_sax_pureperl :
+-install_sax_pureperl : pure_install
 -\t\@\$(PERL) -MXML::SAX -e "XML::SAX->add_parser(q(XML::SAX::PurePerl))->save_parsers()"
 -
 -INSTALL
@@ -43,4 +42,4 @@
 -
 -    return $script;
 -}
--
+ 

--- a/perl-XML-Simple/PKGBUILD
+++ b/perl-XML-Simple/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=XML-Simple
 pkgname=perl-${_realname}
-pkgver=2.24
+pkgver=2.25
 pkgrel=1
 groups=('perl-modules')
 pkgdesc="Simple XML parser for perl"
@@ -12,7 +12,7 @@ url="http://search.cpan.org/dist/${_realname}/"
 depends=('perl-XML-Parser' 'perl')
 options=('!emptydirs')
 source=("https://cpan.org/authors/id/G/GR/GRANTM/${_realname}-${pkgver}.tar.gz")
-sha256sums=('9a14819fd17c75fbb90adcec0446ceab356cab0ccaff870f2e1659205dc2424f')
+sha256sums=('531fddaebea2416743eb5c4fdfab028f502123d9a220405a4100e68fc480dbf8')
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/perl-YAML-Tiny/PKGBUILD
+++ b/perl-YAML-Tiny/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=YAML-Tiny
 pkgname=perl-${_realname}
-pkgver=1.70
+pkgver=1.73
 pkgrel=1
 pkgdesc="Read/Write YAML files with as little code as possible"
 arch=('any')
@@ -12,7 +12,7 @@ license=('GPL' 'PerlArtistic')
 depends=('perl')
 options=('!emptydirs')
 source=(https://www.cpan.org/authors/id/E/ET/ETHER/${_realname}-${pkgver}.tar.gz)
-sha256sums=('bbce4b52b5eafdb04e3043975a08dbf394d00b7d2c958adb9d03d9f7e9291255')
+sha256sums=('bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/perl-libwww/PKGBUILD
+++ b/perl-libwww/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 pkgname=perl-libwww
-pkgver=6.31
-pkgrel=2
+pkgver=6.33
+pkgrel=1
 pkgdesc="The World-Wide Web library for Perl"
 arch=('any')
 url="https://metacpan.org/release/libwww-perl"
@@ -15,13 +15,13 @@ depends=('perl' 'perl-Encode-Locale' 'perl-File-Listing'
          'perl-Net-HTTP' 'perl-URI' 'perl-WWW-RobotRules'
          'perl-HTTP-Message' 'perl-Try-Tiny')
 optdepends=('perl-LWP-Protocol-https: for https:// url schemes')
-source=(https://www.cpan.org/authors/id/E/ET/ETHER/libwww-perl-${pkgver}.tar.gz)
-sha256sums=('525d5386d39d1c1d7da8a0e9dd0cbab95cba2a4bfcfd9b83b257f49be4eecae3')
+checkdepends=('perl-Test-Fatal' 'perl-Test-Requiresinternet')
+source=(https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-${pkgver}.tar.gz)
+sha256sums=('97417386f11f007ae129fe155b82fd8969473ce396a971a664c8ae6850c69b99')
 
 build() {
   cd libwww-perl-${pkgver}
   perl Makefile.PL INSTALLDIRS=vendor
-  #--aliases
   make
 }
 


### PR DESCRIPTION
perl-XML-SAX: Update to 1.00
perl-YAML-Tiny: Update to 1.73
perl-Mozilla-CA: Update to 20180117
New package: perl-Test-Fatal (version: 0.014)
New package: perl-Test-Requiresinternet (version: 0.05)
perl-libwww: Update to 6.33
perl-XML-Simple: Update to 2.25
perl-Test-Pod: Update to 1.52
New package: perl-Test-Needs (version: 0.002005)
perl-URI: Update to 1.74 