### PR TITLE
better support for Win10 OpenSSH server

### DIFF
--- a/filesystem/PKGBUILD
+++ b/filesystem/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
 pkgname=filesystem
-pkgver=2018.06
+pkgver=2018.08
 pkgrel=1
 pkgdesc='Base filesystem'
 arch=('i686' 'x86_64')
@@ -49,7 +49,7 @@ source=('bash.bash_logout'
         'mingw32-config.site'
         'redirect-config.site')
 sha256sums=('6d651f6b0b2d173961a3fa21acd9d44c783ed9cd73a031687698c8b9ed1f6dee'
-            '4995deb0c6a2b5482ba62759f1f5bcdd19186528d99d263dc8bc61d42878798e'
+            'fd1ecf1748391ace014ab8c1416451ce33eb9ed153f58b6403285d18f9961222'
             '99eae6e37081edd73b399009c85f4a67a0c14481241ee4937ab45c4178b540fb'
             'ed08a8bd0919ba29ec5dd2d0c74ba74324ca2bcbf7852354b0b6c523809029a0'
             '4330edf340394d0dae50afb04ac2a621f106fe67fb634ec81c4bfb98be2a1eb5'

--- a/filesystem/bash.bashrc
+++ b/filesystem/bash.bashrc
@@ -15,6 +15,11 @@
 # If not running interactively, don't do anything
 [[ "$-" != *i* ]] && return
 
+# If started from sshd, make sure profile is sourced
+if [[ -n "$SSH_CONNECTION" ]] && [[ "$PATH" != *:/usr/bin* ]]; then
+    source /etc/profile
+fi
+
 # Warnings
 unset _warning_found
 for _warning_prefix in '' ${MINGW_PREFIX}; do


### PR DESCRIPTION
If msys2 bash is set as the DefaultShell for the Win10 OpenSSH server,
there is no way to pass -l to make it a login shell, so /etc/profile is
not sourced, PATH is not set, and the bashrc produces errors.

Detect this case in /etc/bash.bashrc, by checking for the SSH_CONNECTION
environment variable and PATH not having msys2 elements, and source
/etc/profile.