### PR TITLE
ci-library.sh: No exeutables failure fix

### DIFF
--- a/ci-library.sh
+++ b/ci-library.sh
@@ -204,8 +204,8 @@ check_recipe_quality() {
 list_dll_deps(){
     local target="${1}"
     echo "$(tput setaf 2)MSYS2 DLL dependencies:$(tput sgr0)"
-    exes=$(find $target -regex ".*\.\(exe\|dll\)")
-    [[ -n $exes ]] && ldd $exes | GREP_COLOR="1;35" grep --color=always "msys-.*\|"
+    find "$target" -regex ".*\.\(exe\|dll\)" -print0 | xargs -0 -r ldd | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
+    || echo "        None"
 }
 
 # Status functions


### PR DESCRIPTION
CI build fails if package has no `.exe`or `.dll` files. Previous fix still fails because function still returns non-zero status from `[[ -n $exes ]]` test. This fixes this and prints "None" instead. Also handles arbitrary filenames.