### PR TITLE
Silence texinfo deprecation warnings with recent Perl

### DIFF
--- a/texinfo/0006-Fix-unescaped-left-braces-in-regexps-deprecated-sinc.patch
+++ b/texinfo/0006-Fix-unescaped-left-braces-in-regexps-deprecated-sinc.patch
@@ -1,0 +1,32 @@
+From 1f27900352e04ff4f19bec1c1e9635adad2be31c Mon Sep 17 00:00:00 2001
+From: Niko Tyni <ntyni@debian.org>
+Date: Fri, 18 May 2018 10:40:00 +0100
+Subject: [PATCH] Fix unescaped left braces in regexps, deprecated since Perl
+ 5.27.8
+
+This fixes test failures on recent Perl versions.
+---
+ tp/Texinfo/Parser.pm | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tp/Texinfo/Parser.pm b/tp/Texinfo/Parser.pm
+index dc32ca2..c577aa9 100644
+--- a/tp/Texinfo/Parser.pm
++++ b/tp/Texinfo/Parser.pm
+@@ -5478,11 +5478,11 @@ sub _parse_special_misc_command($$$$)
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1;
+       $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
+       $has_comment = 1 if (defined($4));
+     } else {
+       $self->line_error (sprintf($self->__(
+-- 
+2.17.0
+

--- a/texinfo/PKGBUILD
+++ b/texinfo/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('texinfo' 'info' 'texinfo-tex')
 pkgver=6.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Utilities to work with and produce manuals, ASCII text, and on-line documentation from a single source file"
 arch=('i686' 'x86_64')
 url="https://www.gnu.org/software/texinfo/"
@@ -12,13 +12,15 @@ source=(https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgname}-${pkgver}.tar.xz{,.sig
         0001-texinfo-6.5-msys2.patch
         0002-manifest.all.patch
         0004-no-w32-stuff.msys2.patch
-        0005-fix-makeinfo-exeext.msys2.patch)
+        0005-fix-makeinfo-exeext.msys2.patch
+        0006-Fix-unescaped-left-braces-in-regexps-deprecated-sinc.patch)
 sha256sums=('77774b3f4a06c20705cc2ef1c804864422e3cf95235e965b1f00a46df7da5f62'
             'SKIP'
             '4ce942aa3a0fc16dbaf069b1b67d4281f961b7f9c87332810b2dc763ce710bb2'
             '5bc6680fa441b26ed18a794ad201a1252dba9f03d5426c87e42d33c758a4a039'
             'ccf696f2777ebd2c85c4cb311a4735957ffa40952ecbe50c7031b9f05dc6cdee'
-            'e5b18f11d9a5d99f96f9228266e6204cfb2e076e2d9c336db0eceb72e2252873')
+            'e5b18f11d9a5d99f96f9228266e6204cfb2e076e2d9c336db0eceb72e2252873'
+            '8932b1b40d3e95bac89c30446d11c455d7ef3ae2f06ca031508f2607c788f0d0')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -26,6 +28,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0002-manifest.all.patch
   patch -p1 -i ${srcdir}/0004-no-w32-stuff.msys2.patch
   patch -p1 -i ${srcdir}/0005-fix-makeinfo-exeext.msys2.patch
+  patch -p1 -i ${srcdir}/0006-Fix-unescaped-left-braces-in-regexps-deprecated-sinc.patch
 
   autoreconf -fiv
   pushd tp/Texinfo/Convert/XSParagraph


### PR DESCRIPTION
Patch obtained from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=898994