### PR TITLE
pacman: make file list comparisons between packages case insensitive

### DIFF
--- a/pacman/0010-filelist-strcasecmp.patch
+++ b/pacman/0010-filelist-strcasecmp.patch
@@ -1,0 +1,95 @@
+This makes _alpm_filelist_difference() and _alpm_filelist_intersection() take
+into account that filenames are case insensitive (only for ASCII, unicode is
+still broken). This fixes conflict detection in case two packages share the
+same filename with a different case.
+--- pacman-5.1.1-orig/lib/libalpm/filelist.c	2018-05-14 02:02:18.000000000 +0200
++++ pacman-5.1.1/lib/libalpm/filelist.c	2018-09-28 13:05:47.398469000 +0200
+@@ -25,6 +25,43 @@
+ #include "filelist.h"
+ #include "util.h"
+ 
++#ifdef __MSYS__
++
++#define TOLOWER(c) (((c) >= 'A' && (c) <= 'Z') ? (c) - 'A' + 'a' : (c))
++
++static int _cmppath(const char *s1, const char *s2)
++{
++	int c1, c2;
++
++	while(*s1 && *s2)
++	{
++		c1 = TOLOWER(*s1);
++		c2 = TOLOWER(*s2);
++		if(c1 != c2)
++			return c1 - c2;
++		s1++;
++		s2++;
++	}
++
++	return *s1 - *s2;
++}
++
++static int _cmpchar(char c1, char c2)
++{
++	return TOLOWER(c1) - TOLOWER(c2);
++}
++#else
++static int _cmppath(const char *s1, const char *s2)
++{
++	return strcmp(s1, s2);
++}
++
++static int _cmpchar(char c1, char c2)
++{
++	return c1 - c2;
++}
++#endif
++
+ /* Returns the difference of the provided two lists of files.
+  * Pre-condition: both lists are sorted!
+  * When done, free the list but NOT the contained data.
+@@ -39,7 +76,7 @@
+ 		char *strA = filesA->files[ctrA].name;
+ 		char *strB = filesB->files[ctrB].name;
+ 
+-		int cmp = strcmp(strA, strB);
++		int cmp = _cmppath(strA, strB);
+ 		if(cmp < 0) {
+ 			/* item only in filesA, qualifies as a difference */
+ 			ret = alpm_list_add(ret, strA);
+@@ -63,7 +100,7 @@
+ 
+ static int _alpm_filelist_pathcmp(const char *p1, const char *p2)
+ {
+-	while(*p1 && *p1 == *p2) {
++	while(*p1 && _cmpchar(*p1, *p2) == 0) {
+ 		p1++;
+ 		p2++;
+ 	}
+@@ -75,7 +112,7 @@
+ 		p1++;
+ 	}
+ 
+-	return *p1 - *p2;
++	return _cmpchar(*p1, *p2);
+ }
+ 
+ /* Returns the intersection of the provided two lists of files.
+@@ -115,7 +152,7 @@
+ {
+ 	const alpm_file_t *file1 = f1;
+ 	const alpm_file_t *file2 = f2;
+-	return strcmp(file1->name, file2->name);
++	return _cmppath(file1->name, file2->name);
+ }
+ 
+ alpm_file_t SYMEXPORT *alpm_filelist_contains(alpm_filelist_t *filelist,
+@@ -137,7 +174,7 @@
+ {
+ 	size_t i;
+ 	for(i = 1; i < filelist->count; i++) {
+-		if(strcmp(filelist->files[i - 1].name, filelist->files[i].name) > 0) {
++		if(_cmppath(filelist->files[i - 1].name, filelist->files[i].name) > 0) {
+ 			/* filelist is not pre-sorted */
+ 			qsort(filelist->files, filelist->count,
+ 					sizeof(alpm_file_t), _alpm_files_cmp);

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -65,7 +65,8 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0008-answer-yes-by-default.patch"
         "0009-msys-use-pipe-instead-socket.patch"
         "0050-fix-make-target-dependencies.patch"
-        "0100-contrib.patch")
+        "0100-contrib.patch"
+        "0010-filelist-strcasecmp.patch")
 sha256sums=('be04b9162d62d2567e21402dcbabb5bedfdb03909fa5ec6e8568e02ab325bd8d'
             'SKIP'
             'd47240396476eaf126b2f2a3f6ac77d5b397f5cc80b1c3700ba4fa355c4786c8'
@@ -85,7 +86,8 @@ sha256sums=('be04b9162d62d2567e21402dcbabb5bedfdb03909fa5ec6e8568e02ab325bd8d'
             'e4f6e17af19e17e745a9f1c6b8402f5896229062c82167cb61f8e7d29eda716c'
             '9e8fe5ee78192b0407e80ad2e52cb27569c35974b6c26e465e3d55e19c03d108'
             '5bd66342aff56343aa5e07dbf997d18cc3dcae691cc7d8f83e94fee12b5b61b8'
-            '3bd0cd48d608b31d7df564c50e8d31df58dd38cfaaea9ec0fcceb42936486549')
+            '3bd0cd48d608b31d7df564c50e8d31df58dd38cfaaea9ec0fcceb42936486549'
+            '93be4523fb8c3dd6b56eddfe0b09e666725a62eb43392fee336ba1a328f9ffdd')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -100,6 +102,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0008-answer-yes-by-default.patch
   patch -p1 -i ${srcdir}/0009-msys-use-pipe-instead-socket.patch
   patch -p1 -i ${srcdir}/0050-fix-make-target-dependencies.patch
+  patch -p1 -i ${srcdir}/0010-filelist-strcasecmp.patch
 
   autoreconf -fi
 


### PR DESCRIPTION
In case a package gets upgraded and a filename has changed case this allows
the upgrade to go through without any conflicts.

Similarly in case two different packages contain the same file with
a different case this makes it correctly detect a conflict.

This only handles ASCII parts of paths, so Unicode filenames still can
lead to invalid conflict detection.

Fixes #1426