### PR TITLE
flex: remove redundant change in 'check'

### DIFF
--- a/flex/PKGBUILD
+++ b/flex/PKGBUILD
@@ -41,9 +41,6 @@ build() {
 check() {
   cd ${srcdir}/${pkgname}-${pkgver}
 
-  # these tests used features removed in bison-2.6
-  sed -i -e '/test-bison-yylloc/d' -e '/test-bison-yylval/d' tests/Makefile.in
-
   make check
 }
 


### PR DESCRIPTION
The test names sed tries to eliminate have changed
over the years (prefix 'test-' dropped, hyphen replaced
by underscore). Moreover, the eliminated tests do pass
since the most recent flex/bison versions.

My first PR here. So pretty simple.