### PR TITLE
main-config.site: set default value of var 'as_echo' to 'echo'

### DIFF
--- a/filesystem/main-config.site
+++ b/filesystem/main-config.site
@@ -20,14 +20,14 @@ else
   # Set default 'host' to speedup configure
   if test -z "$build_alias"; then
     build_alias="${MSYSTEM_CARCH-x86_64}-pc-msys"  && \
-      $as_echo "$config_site_me:${as_lineno-$LINENO}: default build_alias set to $build_alias" >&5 
+      ${as_echo-echo} "$config_site_me:${as_lineno-$LINENO}: default build_alias set to $build_alias" >&5
   fi
 
   # Set default 'prefix' to "/usr"
   if ( test -z "$prefix" || test "x$prefix" = "xNONE" ) && \
      ( test -z "$exec_prefix" || test "x$exec_prefix" = "xNONE" ); then
     prefix="${MSYSTEM_PREFIX-/usr}" && \
-      $as_echo "$config_site_me:${as_lineno-$LINENO}: default prefix set to $prefix" >&5
+      ${as_echo-echo} "$config_site_me:${as_lineno-$LINENO}: default prefix set to $prefix" >&5
   fi
 
 fi

--- a/filesystem/mingw32-config.site
+++ b/filesystem/mingw32-config.site
@@ -10,12 +10,12 @@ test -n "${BASH_SOURCE}" 2>/dev/null && config_site_me="${BASH_SOURCE[0]##*/}" |
 # Set default 'host' to speedup configure
 if test -z "$build_alias"; then
   build_alias="${MSYSTEM_CHOST-i686-w64-mingw32}"  && \
-    $as_echo "$config_site_me:${as_lineno-$LINENO}: default build_alias set to $build_alias" >&5 
+    ${as_echo-echo} "$config_site_me:${as_lineno-$LINENO}: default build_alias set to $build_alias" >&5
 fi
 
 # Set default 'prefix' to "/mingw32"
 if ( test -z "$prefix" || test "x$prefix" = "xNONE" ) && \
    ( test -z "$exec_prefix" || test "x$exec_prefix" = "xNONE" ); then
   prefix="${MSYSTEM_PREFIX-/mingw32}" && \
-    $as_echo "$config_site_me:${as_lineno-$LINENO}: default prefix set to $prefix" >&5
+    ${as_echo-echo} "$config_site_me:${as_lineno-$LINENO}: default prefix set to $prefix" >&5
 fi

--- a/filesystem/mingw64-config.site
+++ b/filesystem/mingw64-config.site
@@ -10,12 +10,12 @@ test -n "${BASH_SOURCE}" 2>/dev/null && config_site_me="${BASH_SOURCE[0]##*/}" |
 # Set default 'host' to speedup configure
 if test -z "$build_alias"; then
   build_alias="${MSYSTEM_CHOST-x86_64-w64-mingw32}" && \
-    $as_echo "$config_site_me:${as_lineno-$LINENO}: default build_alias set to $build_alias" >&5 
+    ${as_echo-echo} "$config_site_me:${as_lineno-$LINENO}: default build_alias set to $build_alias" >&5
 fi
 
 # Set default 'prefix' to "/mingw64"
 if ( test -z "$prefix" || test "x$prefix" = "xNONE" ) && \
    ( test -z "$exec_prefix" || test "x$exec_prefix" = "xNONE" ); then
   prefix="${MSYSTEM_PREFIX-/mingw64}" && \
-    $as_echo "$config_site_me:${as_lineno-$LINENO}: default prefix set to $prefix" >&5
+    ${as_echo-echo} "$config_site_me:${as_lineno-$LINENO}: default prefix set to $prefix" >&5
 fi


### PR DESCRIPTION
The variable 'as_echo' is not set in a virgin shell, but by 'autoconf'
and friends. Setting the default value to 'echo' facilitates running
'configure' in a virgin shell.

* filesystem/main-config.site: see above.
* filesystem/mingw32-config.site: see above.
* filesystem/mingw64-config.site: see above.

Fixes #1518