### PR TITLE
pacman: fix bash_completion script

### DIFF
--- a/pacman/0011-bash-completion-fix-regex.patch
+++ b/pacman/0011-bash-completion-fix-regex.patch
@@ -1,0 +1,31 @@
+Unlike glibc, msys2-runtime does not seem to implement \w and \s.
+This replaces them with equivalent classes.
+--- a/scripts/completion/bash_completion.in
++++ b/scripts/completion/bash_completion.in
+@@ -24,7 +24,7 @@
+ }
+ 
+ _arch_incomp() {
+-  local r="\s-(-${1#* }\s|\w*${1% *})"; [[ $COMP_LINE =~ $r ]]
++  local r="[[:space:]]-(-${1#* }[[:space:]]|[[:alnum:]_]*${1% *})"; [[ $COMP_LINE =~ $r ]]
+ }
+ 
+ _pacman_keyids() {
+@@ -74,7 +74,7 @@
+   local cur opts prev
+   COMPREPLY=()
+   _get_comp_words_by_ref cur prev
+-  if [[ $cur = -* && ! $prev =~ ^-(-(config|help|key|version)$|\w*[Vhp]) ]]; then
++  if [[ $cur = -* && ! $prev =~ ^-(-(config|help|key|version)$|[[:alnum:]_]*[Vhp]) ]]; then
+     opts=('allsource asdeps check clean cleanbuild config force geninteg help
+            holdver ignorearch install key log needed noarchive nobuild nocheck
+            nocolor noconfirm nodeps noextract noprepare noprogressbar nosign
+@@ -123,7 +123,7 @@
+ 
+   if [[ $? != 0 ]]; then
+     _arch_ptr2comp core
+-  elif [[ ! $prev =~ ^-\w*[Vbhr] &&
++  elif [[ ! $prev =~ ^-[[:alnum:]_]*[Vbhr] &&
+     ! $prev = --@(cachedir|color|config|dbpath|help|hookdir|gpgdir|logfile|root|version) ]]
+   then
+     [[ $cur = -* ]] && _arch_ptr2comp ${o#* } common ||

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=pacman
 pkgver=5.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A library-based package manager with dependency support (MSYS2 port)"
 arch=('i686' 'x86_64')
 url="https://www.archlinux.org/pacman/"
@@ -69,7 +69,8 @@ source=(https://sources.archlinux.org/other/pacman/${pkgname}-${pkgver}.tar.gz{,
         "0009-msys-use-pipe-instead-socket.patch"
         "0050-fix-make-target-dependencies.patch"
         "0100-contrib.patch"
-        "0010-filelist-strcasecmp.patch")
+        "0010-filelist-strcasecmp.patch"
+        "0011-bash-completion-fix-regex.patch")
 sha256sums=('ce4eef1585fe64fd1c65c269e263577261edd7535fe2278240103012d74b6ef6'
             'SKIP'
             'd47240396476eaf126b2f2a3f6ac77d5b397f5cc80b1c3700ba4fa355c4786c8'
@@ -93,7 +94,8 @@ sha256sums=('ce4eef1585fe64fd1c65c269e263577261edd7535fe2278240103012d74b6ef6'
             '9e8fe5ee78192b0407e80ad2e52cb27569c35974b6c26e465e3d55e19c03d108'
             '5bd66342aff56343aa5e07dbf997d18cc3dcae691cc7d8f83e94fee12b5b61b8'
             '3bd0cd48d608b31d7df564c50e8d31df58dd38cfaaea9ec0fcceb42936486549'
-            '93be4523fb8c3dd6b56eddfe0b09e666725a62eb43392fee336ba1a328f9ffdd')
+            '93be4523fb8c3dd6b56eddfe0b09e666725a62eb43392fee336ba1a328f9ffdd'
+            '1f164d20f55f17f832d8dbfac7e59044b11d806ea99e3233d2950766d89b4cf6')
 
 prepare() {
   cd ${srcdir}/${pkgname}-${pkgver}
@@ -109,6 +111,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0009-msys-use-pipe-instead-socket.patch
   patch -p1 -i ${srcdir}/0050-fix-make-target-dependencies.patch
   patch -p1 -i ${srcdir}/0010-filelist-strcasecmp.patch
+  patch -p1 -i ${srcdir}/0011-bash-completion-fix-regex.patch
 
   autoreconf -fi
 


### PR DESCRIPTION
The bash_completion script uses \w and \s character classes in its regex, but these do not seem to be implemented in msys2-runtime (for the =~ operator, bash uses the POSIX regcomp/regexec functions which are implemented there). This makes it impossible to auto-complete package names, and probably other things.

This patch replaces them which [[:alnum:]_] and [[:space:]] classes that are implemented and match the same characters.

Not sure if this should be reported upstream since glibc does implement these classes, so the bug does not happen in Arch Linux.