### PR TITLE
git-flow: upgrade to v1.12.0

### DIFF
--- a/git-flow/PKGBUILD
+++ b/git-flow/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=git-flow
 pkgname="${_realname}"
-pkgver=1.11.0
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="Git extensions to provide high-level repository operations for Vincent Driessen's branching model (AVH edition)"
 arch=('i686' 'x86_64')


### PR DESCRIPTION
A new version has been released 2 days ago.