### PR TITLE
openssl: Patch to avoid potential infinite loops

### DIFF
--- a/openssl/0005-Make-OPENSSL_malloc_init-a-no-op.patch
+++ b/openssl/0005-Make-OPENSSL_malloc_init-a-no-op.patch
@@ -1,0 +1,53 @@
+From ef45aa14c5af024fcb8bef1c9007f3d1c115bd85 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 5 Feb 2019 14:25:18 +0000
+Subject: [PATCH] Make OPENSSL_malloc_init() a no-op
+
+Making this a no-op removes a potential infinite loop than can occur in
+some situations.
+
+Fixes #2865
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/8167)
+---
+ doc/man3/OPENSSL_malloc.pod | 6 ++----
+ include/openssl/crypto.h    | 9 ++-------
+ 2 files changed, 4 insertions(+), 11 deletions(-)
+
+diff --git a/doc/man3/OPENSSL_malloc.pod b/doc/man3/OPENSSL_malloc.pod
+index e17ff633b50..f1de27a19c5 100644
+--- a/doc/man3/OPENSSL_malloc.pod
++++ b/doc/man3/OPENSSL_malloc.pod
+@@ -90,10 +90,8 @@ generally macro's that add the standard C B<__FILE__> and B<__LINE__>
+ parameters and call a lower-level B<CRYPTO_xxx> API.
+ Some functions do not add those parameters, but exist for consistency.
+ 
+-OPENSSL_malloc_init() sets the lower-level memory allocation functions
+-to their default implementation.
+-It is generally not necessary to call this, except perhaps in certain
+-shared-library situations.
++OPENSSL_malloc_init() does nothing and does not need to be called. It is
++included for compatibility with older versions of OpenSSL.
+ 
+ OPENSSL_malloc(), OPENSSL_realloc(), and OPENSSL_free() are like the
+ C malloc(), realloc(), and free() functions.
+diff --git a/include/openssl/crypto.h b/include/openssl/crypto.h
+index f9123021170..cbde3d5ef1b 100644
+--- a/include/openssl/crypto.h
++++ b/include/openssl/crypto.h
+@@ -109,12 +109,7 @@ DEFINE_STACK_OF(void)
+ # define CRYPTO_EX_INDEX_DRBG            15
+ # define CRYPTO_EX_INDEX__COUNT          16
+ 
+-/*
+- * This is the default callbacks, but we can have others as well: this is
+- * needed in Win32 where the application malloc and the library malloc may
+- * not be the same.
+- */
+-#define OPENSSL_malloc_init() \
+-    CRYPTO_set_mem_functions(CRYPTO_malloc, CRYPTO_realloc, CRYPTO_free)
++/* No longer needed, so this is a no-op */
++#define OPENSSL_malloc_init() while(0) continue
+ 
+ int CRYPTO_mem_ctrl(int mode);

--- a/openssl/PKGBUILD
+++ b/openssl/PKGBUILD
@@ -5,7 +5,7 @@ _ver=1.1.1a
 
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 pkgdesc='The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
 arch=('i686' 'x86_64')
 url='https://www.openssl.org'
@@ -18,13 +18,15 @@ source=("https://www.openssl.org/source/${pkgname}-${_ver}.tar.gz"{,.asc}
         '0001-Use-usr-ssl-as-ca-dir-instead-of-.-demoCA.patch'
         '0002-Support-MSYS2.patch'
         '0003-tls13secretstest-work-around-multiple-definition-of.patch'
-        '0004-Override-engines-directory.patch')
+        '0004-Override-engines-directory.patch'
+        '0005-Make-OPENSSL_malloc_init-a-no-op.patch')
 sha256sums=('fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41'
             'SKIP'
             '35f5508bc3e651bb2ef1bf9f4e052f531aeaefbbdeff95b9746fff71137fff31'
             '9a4e721ab9fb9c693d0a6bbc3ae0d71456857f83febc1c8412bfdf323e4d69e2'
             'a83dcfeec646724f081f8ff89beccee83c962758aa74d724f263138aa21b2438'
-            '79765cc10799691ae47880556255287c64b8c1f26ea3907ad2e0add97bc9f1fc')
+            '79765cc10799691ae47880556255287c64b8c1f26ea3907ad2e0add97bc9f1fc'
+            'd002c8da62018abc0c6cd5c60796854f468bf181d531606481f6d9aee1916377')
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491')
 
 prepare() {
@@ -35,6 +37,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0002-Support-MSYS2.patch
   patch -p1 -i ${srcdir}/0003-tls13secretstest-work-around-multiple-definition-of.patch
   patch -p1 -i ${srcdir}/0004-Override-engines-directory.patch
+  patch -p1 -i ${srcdir}/0005-Make-OPENSSL_malloc_init-a-no-op.patch
 }
 
 build() {


### PR DESCRIPTION
One affected package is libserf (msys-serf-1-0.dll). This can be seen
when using certain operations of git svn.