### PR TITLE
serf: Rebuild with openssl to fix infinite loop issue

### DIFF
--- a/serf/PKGBUILD
+++ b/serf/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=serf
 pkgname=("lib${pkgbase}" "lib${pkgbase}-devel")
 pkgver=1.3.9
-pkgrel=3
+pkgrel=4
 pkgdesc="High-performance asynchronous HTTP client library"
 arch=('i686' 'x86_64')
 url="https://serf.apache.org/"


### PR DESCRIPTION
This is the follow up patch to https://github.com/Alexpux/MSYS2-packages/pull/1576 which will fix various svn related hangs (infinite loops).